### PR TITLE
[TECHNICAL SUPPORT] LPS-144573 Web Content with URL link that only has locale cannot be published due to wrong layout reference validation

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.StagedModel;
@@ -335,6 +336,24 @@ public class LayoutReferencesExportImportContentProcessor
 
 					locale = LocaleUtil.fromLanguageId(
 						localePath.substring(1), true, false);
+				}
+				else {
+					String urlWithoutSlash = url.substring(1);
+
+					Locale localeFromUrl = LocaleUtil.fromLanguageId(
+						urlWithoutSlash, true, false);
+
+					if (localeFromUrl != null) {
+						Layout firstLayout =
+							_layoutLocalService.fetchFirstLayout(
+								group.getGroupId(), false,
+								LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+								false);
+
+						if (firstLayout != null) {
+							url = firstLayout.getFriendlyURL();
+						}
+					}
 				}
 
 				if (locale != null) {
@@ -986,6 +1005,22 @@ public class LayoutReferencesExportImportContentProcessor
 
 				locale = LocaleUtil.fromLanguageId(
 					localePath.substring(1), true, false);
+			}
+			else {
+				String urlWithoutSlash = url.substring(1);
+
+				Locale localeFromUrl = LocaleUtil.fromLanguageId(
+					urlWithoutSlash, true, false);
+
+				if (localeFromUrl != null) {
+					Layout firstLayout = _layoutLocalService.fetchFirstLayout(
+						groupId, false,
+						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, false);
+
+					if (firstLayout != null) {
+						url = firstLayout.getFriendlyURL();
+					}
+				}
 			}
 
 			if (locale != null) {


### PR DESCRIPTION
Hey,
[LPS-144573](https://issues.liferay.com/browse/LPS-144573)

I am not a 100% sure if we should allow the usage of relative urls that only contain the locale, as its not really a reference to the main page, we simply just assume the intent. However I handle this scenario in my solution.
However these urls will be replaced to a relative url pointing to the "main" page after export.

Please review it.

Thanks,