### PR TITLE
[TS] LPS-142076

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -974,22 +974,47 @@ public class JournalArticleStagedModelDataHandler
 				}
 			}
 			else {
-				importedArticle = _journalArticleLocalService.addArticle(
-					externalReferenceCode, userId,
-					portletDataContext.getScopeGroupId(), folderId,
-					article.getClassNameId(), ddmStructureId, articleId,
-					autoArticleId, article.getVersion(), article.getTitleMap(),
-					article.getDescriptionMap(), friendlyURLMap, content,
-					parentDDMStructureKey, parentDDMTemplateKey,
-					article.getLayoutUuid(), displayDateMonth, displayDateDay,
-					displayDateYear, displayDateHour, displayDateMinute,
-					expirationDateMonth, expirationDateDay, expirationDateYear,
-					expirationDateHour, expirationDateMinute, neverExpire,
-					reviewDateMonth, reviewDateDay, reviewDateYear,
-					reviewDateHour, reviewDateMinute, neverReview,
-					article.isIndexable(), article.isSmallImage(),
-					article.getSmallImageURL(), smallFile, null, articleURL,
-					serviceContext);
+				JournalArticle existingArticle =
+					_journalArticleLocalService.fetchArticle(
+						portletDataContext.getScopeGroupId(), articleId,
+						article.getVersion());
+
+				if (existingArticle == null) {
+					importedArticle = _journalArticleLocalService.addArticle(
+						externalReferenceCode, userId,
+						portletDataContext.getScopeGroupId(), folderId,
+						article.getClassNameId(), ddmStructureId, articleId,
+						autoArticleId, article.getVersion(),
+						article.getTitleMap(), article.getDescriptionMap(),
+						friendlyURLMap, content, parentDDMStructureKey,
+						parentDDMTemplateKey, article.getLayoutUuid(),
+						displayDateMonth, displayDateDay, displayDateYear,
+						displayDateHour, displayDateMinute, expirationDateMonth,
+						expirationDateDay, expirationDateYear,
+						expirationDateHour, expirationDateMinute, neverExpire,
+						reviewDateMonth, reviewDateDay, reviewDateYear,
+						reviewDateHour, reviewDateMinute, neverReview,
+						article.isIndexable(), article.isSmallImage(),
+						article.getSmallImageURL(), smallFile, null, articleURL,
+						serviceContext);
+				}
+				else {
+					importedArticle = _journalArticleLocalService.updateArticle(
+						userId, portletDataContext.getScopeGroupId(), folderId,
+						articleId, article.getVersion(), article.getTitleMap(),
+						article.getDescriptionMap(), friendlyURLMap, content,
+						parentDDMStructureKey, parentDDMTemplateKey,
+						article.getLayoutUuid(), displayDateMonth,
+						displayDateDay, displayDateYear, displayDateHour,
+						displayDateMinute, expirationDateMonth,
+						expirationDateDay, expirationDateYear,
+						expirationDateHour, expirationDateMinute, neverExpire,
+						reviewDateMonth, reviewDateDay, reviewDateYear,
+						reviewDateHour, reviewDateMinute, neverReview,
+						article.isIndexable(), article.isSmallImage(),
+						article.getSmallImageURL(), smallFile, null, articleURL,
+						serviceContext);
+				}
 			}
 
 			Map<Long, Long> primaryKeys =


### PR DESCRIPTION
First I tired to solve [LPS-142076](https://issues.liferay.com/browse/LPS-142076) by removing its root cause: multiple import of the same web content. The issue was introduced by [LPS-142076](https://issues.liferay.com/browse/LPS-142076) , commit https://github.com/liferay/liferay-portal/commit/ab10b7ceb14ae57d054ce1bbe31f790efe2227a7 . This was required because the caching added in [LPS-116999](https://issues.liferay.com/browse/LPS-116999) (commit: https://github.com/liferay/liferay-portal/commit/c8d031a9dde38f7c5ee0f97ec6a48b9a65612d90 ) prevented adding the dependencies of the exported web content in multiple places, when it was exported in the contexts of multiple portlets.
I hoped I could get rid of the double-import, if I manage to also cache references, and not just the content of the JournalArticles (since `ExportImportContentProcessor`s have two roles: replace the references in the content but also collect them for export): https://github.com/vendeltoreki/liferay-portal/pull/240 .
This did not work correctly, as it caused the `LocalFile.ExportImport#ExportImportLayoutCircularReference` test case to fail. The error of [LPS-133752](https://issues.liferay.com/browse/LPS-133752) is thrown in [DDMFormValuesExportImportContentProcessor](https://github.com/liferay/liferay-portal/blob/bf077ffee4a49806de512fac7bbd1d3203153855/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java#L738), when we try to replace the Link to Page field and add the page's full name (breadcrumbs) in the JSON field. At this point, the parent page of "childpage" is not imported yet, and thus, the breadcrumb name can not be generated. I don't really see any reliable way to get around this issue yet. The Layouts can not be imported out of their default order, even when they are referenced from JournalArticles (which are imported by the JournalPortlet before the Layouts).

So it seems like the only solution is to accept the double import for now, and prepare the `JournalArticleStagedModelDataHandler` to handle this scenario, when a JournalArticle already exists and the import method is 'Copy as New'.