### PR TITLE
LPS-148699 Fix ResourcePermission deletion for LayoutBranch - LPS-145396 Subtask

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.LayoutBranchConstants;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutRevisionConstants;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.RecentLayoutBranchLocalService;
@@ -135,6 +136,11 @@ public class LayoutBranchLocalServiceImpl
 			layoutBranch.getPlid());
 
 		_recentLayoutBranchLocalService.deleteRecentLayoutBranches(
+			layoutBranch.getLayoutBranchId());
+
+		_resourceLocalService.deleteResource(
+			layoutBranch.getCompanyId(), LayoutBranch.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
 			layoutBranch.getLayoutBranchId());
 
 		return deleteLayoutBranch(layoutBranch);


### PR DESCRIPTION
When we delete some types of objects in Liferay, we are not deleting their ResourcePermission records, leaving some database wrong references.

For more information see parent LPS-145396

This subtask addresses the issue for Staging team code

/cc @tinatian
