### PR TITLE
[TS] LPS-149307 | Links configured in page fragments within site templates don't work on sites when converted to public pages

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesLayoutMappingExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesLayoutMappingExportImportContentProcessor.java
@@ -175,6 +175,8 @@ public class EditableValuesLayoutMappingExportImportContentProcessor
 			"layoutId", layout.getLayoutId()
 		).put(
 			"layoutUuid", layout.getUuid()
+		).put(
+			"privateLayout", layout.isPrivateLayout()
 		);
 	}
 


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-149307
Best,
Attila