### PR TITLE
[TS] LPS-150134 Prefer the scopeGroupId from the current layout instead of the live layout

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4823,16 +4823,23 @@ public class PortalImpl implements Portal {
 				if (liveGroup.isStaged() &&
 					!liveGroup.isStagedPortlet(portletId)) {
 
-					Layout liveGroupLayout =
-						LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-							layout.getUuid(), liveGroup.getGroupId(),
-							layout.isPrivateLayout());
+					long portletScopeGroupId = _getScopeGroupId(
+						themeDisplay, layout, portletId);
 
-					if ((liveGroupLayout != null) &&
-						liveGroupLayout.hasScopeGroup()) {
+					if (portletScopeGroupId != layout.getGroupId()) {
+						Group portletScopeGroup =
+							GroupLocalServiceUtil.fetchGroup(
+								portletScopeGroupId);
 
-						scopeGroupId = _getScopeGroupId(
-							themeDisplay, liveGroupLayout, portletId);
+						if (portletScopeGroup.isStagingGroup()) {
+							Group portletScopeLiveGroup =
+								portletScopeGroup.getLiveGroup();
+
+							scopeGroupId = portletScopeLiveGroup.getGroupId();
+						}
+						else {
+							scopeGroupId = portletScopeGroup.getGroupId();
+						}
 					}
 					else if (checkStagingGroup &&
 							 !liveGroup.isStagedRemotely()) {


### PR DESCRIPTION
The previous logic would fetch the scope group ID from the live site, even if the user was viewing the staging site. This leads to issues because the widget's scope could potentially be different on staging than it is in live due to not being published yet. 

Additionally, this logic was not executed in the case of the live site because it failed the check `liveGroupLayout.hasScopeGroup()`. The scope could be a completely different layout or, in the case of staging, the scope group is the staged layout and not the live layout.

These changes use similar logic to `getPortletTitle` (https://github.com/liferay-staging/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L4577-L4580). If there is a scope group ID then it should be preferred. We then get the live group associated with that ID in order to fetch the correct data for the widget.

There are five cases that need to be considered for these changes:

1. Staging content page draft
2. Staging content page
3. Live content page
4. Staging widget page
5. Live widget page

I tested the content pages by:

1. Changing the scope of the staging content page draft and confirm it shows different content than the staging and live pages
2. Publish the page and confirm the staging page shows different content than the live page
3. Publish the page to live and confirm all three pages show the same content

I tested widget pages in the same way but omitting the draft portion. In all of these cases the code changes work as expected.

Since this is intricate logic and the code is rather old please let me know if you see any regressions or issues with the changes. If there are any questions please let me know as well.

Thank you.