### PR TITLE
[TS] LPS-150838 Only import preferences to the current group

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -603,9 +603,13 @@ public class PortletImportControllerImpl implements PortletImportController {
 						}
 					}
 
-					exportImportPortletPreferencesProcessor.
-						processImportPortletPreferences(
-							portletDataContext, jxPortletPreferences);
+					if (portletDataContext.getGroupId() ==
+							portletDataContext.getScopeGroupId()) {
+
+						exportImportPortletPreferencesProcessor.
+							processImportPortletPreferences(
+								portletDataContext, jxPortletPreferences);
+					}
 				}
 			}
 			finally {


### PR DESCRIPTION
If this file doesn't belong to the Staging team please let me know a better team to send it to for review.

From @noornajj:

> https://issues.liferay.com/browse/LPS-150838
> 
> The issue here is that the Global portlet permissions were being overwritten when importing site preferences and a widget was scoped to the Global site. It was occurring due to the global site being passed [here](https://github.com/liferay/liferay-portal-ee/blob/b61b73224e3dbf621004761d7480b9a1184dd02d/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java#L1488) as the new resource and being overwritten by the imported site's settings
> 
> To fix the issue, I added an if statement to see whether the portlet being updated belongs to the new site. To do that, I check whether the current site's groupId is the same as the portlet's scopeGroupId