### PR TITLE
LPS-151464 Check if the page exists with the urlWithoutLocale in more cases (not only if the URL only has 1 slash)

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1022,6 +1022,11 @@ public class LayoutReferencesExportImportContentProcessor
 							group.getGroupId(), false, urlWithoutLocale);
 
 					if (layout != null) {
+						layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+							group.getGroupId(), true, urlWithoutLocale);
+					}
+
+					if (layout != null) {
 						urlSB.append(localePath);
 
 						url = urlWithoutLocale;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1006,25 +1006,25 @@ public class LayoutReferencesExportImportContentProcessor
 
 					url = urlWithoutLocale;
 				}
-				else if (urlWithoutLocale.indexOf(StringPool.SLASH, 1) == -1) {
-					if (!localePath.equals(_PRIVATE_GROUP_SERVLET_MAPPING) &&
-						!localePath.equals(_PRIVATE_USER_SERVLET_MAPPING) &&
-						!localePath.equals(_PUBLIC_GROUP_SERVLET_MAPPING)) {
+				else if ((urlWithoutLocale.indexOf(StringPool.SLASH, 1) ==
+							-1) &&
+						 !localePath.equals(_PRIVATE_GROUP_SERVLET_MAPPING) &&
+						 !localePath.equals(_PRIVATE_USER_SERVLET_MAPPING) &&
+						 !localePath.equals(_PUBLIC_GROUP_SERVLET_MAPPING)) {
 
+					urlSB.append(localePath);
+
+					url = urlWithoutLocale;
+				}
+				else {
+					Layout layout =
+						_layoutLocalService.fetchLayoutByFriendlyURL(
+							group.getGroupId(), false, urlWithoutLocale);
+
+					if (layout != null) {
 						urlSB.append(localePath);
 
 						url = urlWithoutLocale;
-					}
-					else {
-						Layout layout =
-							_layoutLocalService.fetchLayoutByFriendlyURL(
-								group.getGroupId(), false, urlWithoutLocale);
-
-						if (layout != null) {
-							urlSB.append(localePath);
-
-							url = urlWithoutLocale;
-						}
 					}
 				}
 			}


### PR DESCRIPTION
Sending this because the urls with locale and more than 1 slash (for example /en/test/test are not passing the validation because the locale is not been removed when needed.