### PR TITLE
Create tests for LPS-150134

### DIFF
--- a/modules/apps/staging/staging-test/build.gradle
+++ b/modules/apps/staging/staging-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationCompile project(":apps:blogs:blogs-api")
 	testIntegrationCompile project(":apps:dynamic-data-lists:dynamic-data-lists-api")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/BaseLocalStagingTestCase.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/BaseLocalStagingTestCase.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.test;
+
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
+import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.exportimport.kernel.staging.constants.StagingConstants;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.junit.Before;
+
+/**
+ * @author Tamas Molnar
+ */
+public abstract class BaseLocalStagingTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		liveGroup = GroupTestUtil.addGroup();
+
+		_enableLocalStaging();
+
+		stagingGroup = liveGroup.getStagingGroup();
+
+		stagingLayout = LayoutTestUtil.addTypePortletLayout(stagingGroup);
+
+		publishLayouts();
+
+		liveLayout = LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
+			stagingLayout.getUuid(), liveGroup.getGroupId(),
+			stagingLayout.isPrivateLayout());
+	}
+
+	protected String[] getNotStagedPortletIds() {
+		return new String[0];
+	}
+
+	protected void publishLayouts() throws PortalException {
+		publishLayouts(
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap());
+	}
+
+	protected void publishLayouts(Map<String, String[]> parameterMap)
+		throws PortalException {
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			liveGroup.getGroupId(), false, parameterMap);
+	}
+
+	protected void publishPortlet(String portletId) throws PortalException {
+		StagingUtil.publishPortlet(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			liveGroup.getGroupId(), stagingLayout.getPlid(),
+			liveLayout.getPlid(), portletId,
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap());
+	}
+
+	protected void setPortletStagingEnabled(
+		boolean enabled, String portletId, ServiceContext serviceContext) {
+
+		serviceContext.setAttribute(
+			StringBundler.concat(
+				StagingConstants.STAGED_PREFIX, StagingConstants.STAGED_PORTLET,
+				portletId, StringPool.DOUBLE_DASH),
+			Boolean.FALSE.toString());
+	}
+
+	@DeleteAfterTestRun
+	protected Group liveGroup;
+
+	protected Layout liveLayout;
+	protected Group stagingGroup;
+	protected Layout stagingLayout;
+
+	private void _enableLocalStaging() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(liveGroup.getGroupId());
+
+		Map<String, Serializable> attributes = serviceContext.getAttributes();
+
+		attributes.putAll(
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap());
+
+		for (String portletId : getNotStagedPortletIds()) {
+			setPortletStagingEnabled(false, portletId, serviceContext);
+		}
+
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), liveGroup, false, false,
+			serviceContext);
+	}
+
+}

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingDataPortletPreferencesTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingDataPortletPreferencesTest.java
@@ -29,10 +29,7 @@ import com.liferay.dynamic.data.mapping.test.util.DDMFormInstanceTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
-import com.liferay.exportimport.kernel.lar.ExportImportDateUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
-import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
-import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.journal.constants.JournalContentPortletKeys;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
@@ -41,26 +38,15 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.rule.Sync;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.staging.configuration.StagingConfiguration;
 import com.liferay.wiki.constants.WikiPortletKeys;
 import com.liferay.wiki.model.WikiNode;
@@ -69,15 +55,12 @@ import com.liferay.wiki.service.WikiNodeLocalService;
 import com.liferay.wiki.service.WikiPageLocalService;
 import com.liferay.wiki.test.util.WikiTestUtil;
 
-import java.io.Serializable;
-
 import java.util.Map;
 
 import javax.portlet.PortletPreferences;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -88,15 +71,13 @@ import org.junit.runner.RunWith;
  * @author Tamas Molnar
  */
 @RunWith(Arquillian.class)
-@Sync(cleanTransaction = true)
-public class StagingDataPortletPreferencesTest {
+public class StagingDataPortletPreferencesTest
+	extends BaseLocalStagingTestCase {
 
 	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -111,19 +92,6 @@ public class StagingDataPortletPreferencesTest {
 	public static void tearDownClass() throws Exception {
 		ConfigurationTestUtil.deleteConfiguration(
 			StagingConfiguration.class.getName());
-	}
-
-	@Before
-	public void setUp() throws Exception {
-		UserTestUtil.setUser(TestPropsValues.getUser());
-
-		liveGroup = GroupTestUtil.addGroup();
-
-		enableLocalStaging();
-
-		stagingGroup = liveGroup.getStagingGroup();
-
-		stagingLayout = LayoutTestUtil.addTypePortletLayout(stagingGroup);
 	}
 
 	@Test
@@ -175,7 +143,7 @@ public class StagingDataPortletPreferencesTest {
 			String.valueOf(ddlRecordSet.getRecordSetId()),
 			livePortletPreferences.getValue("recordSetId", StringPool.BLANK));
 
-		publishPortletData(DDLPortletKeys.DYNAMIC_DATA_LISTS);
+		publishPortlet(DDLPortletKeys.DYNAMIC_DATA_LISTS);
 
 		publishLayoutWithDisplayPortlet(portletId, preferenceMap, false);
 
@@ -224,7 +192,7 @@ public class StagingDataPortletPreferencesTest {
 			livePortletPreferences.getValue(
 				"formInstanceId", StringPool.BLANK));
 
-		publishPortletData(DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN);
+		publishPortlet(DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN);
 
 		publishLayoutWithDisplayPortlet(portletId, preferenceMap, false);
 
@@ -258,7 +226,7 @@ public class StagingDataPortletPreferencesTest {
 			journalArticle.getArticleId(),
 			livePortletPreferences.getValue("articleId", StringPool.BLANK));
 
-		publishPortletData(JournalPortletKeys.JOURNAL);
+		publishPortlet(JournalPortletKeys.JOURNAL);
 
 		publishLayoutWithDisplayPortlet(portletId, preferenceMap, false);
 
@@ -294,7 +262,7 @@ public class StagingDataPortletPreferencesTest {
 			wikiPage.getTitle(),
 			livePortletPreferences.getValue("title", StringPool.BLANK));
 
-		publishPortletData(WikiPortletKeys.WIKI);
+		publishPortlet(WikiPortletKeys.WIKI);
 
 		publishLayoutWithDisplayPortlet(portletId, preferenceMap, false);
 
@@ -312,21 +280,6 @@ public class StagingDataPortletPreferencesTest {
 		Assert.assertEquals(
 			liveWikiPage.getTitle(),
 			livePortletPreferences.getValue("title", StringPool.BLANK));
-	}
-
-	protected void enableLocalStaging() throws PortalException {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(liveGroup.getGroupId());
-
-		Map<String, Serializable> attributes = serviceContext.getAttributes();
-
-		attributes.putAll(
-			ExportImportConfigurationParameterMapFactoryUtil.
-				buildParameterMap());
-
-		StagingLocalServiceUtil.enableLocalStaging(
-			TestPropsValues.getUserId(), liveGroup, false, false,
-			serviceContext);
 	}
 
 	protected String publishLayoutWithDisplayPortlet(
@@ -347,15 +300,7 @@ public class StagingDataPortletPreferencesTest {
 			PortletDataHandlerKeys.PORTLET_DATA,
 			new String[] {Boolean.FALSE.toString()});
 
-		StagingUtil.publishLayouts(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
-			liveGroup.getGroupId(), false, parameterMap);
-
-		if (liveLayout == null) {
-			liveLayout = LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
-				stagingLayout.getUuid(), liveGroup.getGroupId(),
-				stagingLayout.isPrivateLayout());
-		}
+		publishLayouts(parameterMap);
 
 		livePortletPreferences = LayoutTestUtil.getPortletPreferences(
 			liveLayout, portletId);
@@ -363,28 +308,7 @@ public class StagingDataPortletPreferencesTest {
 		return portletId;
 	}
 
-	protected void publishPortletData(String portletId) throws PortalException {
-		Map<String, String[]> parameterMap =
-			ExportImportConfigurationParameterMapFactoryUtil.
-				buildParameterMap();
-
-		parameterMap.put(
-			ExportImportDateUtil.RANGE,
-			new String[] {ExportImportDateUtil.RANGE_ALL});
-
-		StagingUtil.publishPortlet(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
-			liveGroup.getGroupId(), stagingLayout.getPlid(),
-			liveLayout.getPlid(), portletId, parameterMap);
-	}
-
-	@DeleteAfterTestRun
-	protected Group liveGroup;
-
-	protected Layout liveLayout;
 	protected PortletPreferences livePortletPreferences;
-	protected Group stagingGroup;
-	protected Layout stagingLayout;
 
 	@Inject
 	private DDLRecordSetLocalService _ddlRecordSetLocalService;

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGetScopeGroupIdTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGetScopeGroupIdTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.constants.BlogsPortletKeys;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Tamas Molnar
+ */
+@RunWith(Arquillian.class)
+@Sync(cleanTransaction = true)
+public class StagingGetScopeGroupIdTest extends BaseLocalStagingTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		GroupTestUtil.addGroup(TestPropsValues.getUserId(), liveLayout);
+		GroupTestUtil.addGroup(TestPropsValues.getUserId(), stagingLayout);
+
+		_liveLayoutScopeGroup = liveLayout.getScopeGroup();
+		_stagingLayoutScopeGroup = stagingLayout.getScopeGroup();
+
+		_stagingLayoutScopeGroup.setLiveGroupId(
+			_liveLayoutScopeGroup.getGroupId());
+
+		GroupLocalServiceUtil.updateGroup(_stagingLayoutScopeGroup);
+
+		_mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, stagingLayout);
+	}
+
+	@Ignore
+	@Test
+	public void testGetScopeGroupId() throws Exception {
+		_testGetScopeGroupId(
+			false, false, JournalContentPortletKeys.JOURNAL_CONTENT);
+		_testGetScopeGroupId(
+			false, true, JournalContentPortletKeys.JOURNAL_CONTENT);
+		_testGetScopeGroupId(
+			true, false, JournalContentPortletKeys.JOURNAL_CONTENT);
+		_testGetScopeGroupId(
+			true, true, JournalContentPortletKeys.JOURNAL_CONTENT);
+
+		_testGetScopeGroupId(false, false, BlogsPortletKeys.BLOGS);
+		_testGetScopeGroupId(false, true, BlogsPortletKeys.BLOGS);
+		_testGetScopeGroupId(true, false, BlogsPortletKeys.BLOGS);
+		_testGetScopeGroupId(true, true, BlogsPortletKeys.BLOGS);
+	}
+
+	@Override
+	protected String[] getNotStagedPortletIds() {
+		return new String[] {BlogsPortletKeys.BLOGS_ADMIN};
+	}
+
+	private Group _getExpectedGroup(
+		boolean checkStagingGroup, boolean layoutScopeGroup,
+		String rootPortletId) {
+
+		if (_isStagedPortlet(rootPortletId)) {
+			if (layoutScopeGroup) {
+				return _stagingLayoutScopeGroup;
+			}
+
+			return stagingGroup;
+		}
+
+		if (layoutScopeGroup) {
+			if (checkStagingGroup) {
+				return _stagingLayoutScopeGroup;
+			}
+
+			return _liveLayoutScopeGroup;
+		}
+
+		if (checkStagingGroup) {
+			return stagingGroup;
+		}
+
+		return liveGroup;
+	}
+
+	private Map<String, String[]> _getLayoutScopedPreferenceMap() {
+		return HashMapBuilder.put(
+			"lfrScopeLayoutUuid",
+			new String[] {String.valueOf(stagingLayout.getUuid())}
+		).put(
+			"lfrScopeType", new String[] {"layout"}
+		).build();
+	}
+
+	private boolean _isStagedPortlet(String rootPortletId) {
+		return !ArrayUtil.contains(getNotStagedPortletIds(), rootPortletId);
+	}
+
+	private void _testGetScopeGroupId(
+			boolean checkStagingGroup, boolean layoutScopeGroup,
+			String rootPortletId)
+		throws Exception {
+
+		String portletId = null;
+
+		if (layoutScopeGroup) {
+			portletId = LayoutTestUtil.addPortletToLayout(
+				stagingLayout, rootPortletId, _getLayoutScopedPreferenceMap());
+		}
+		else {
+			portletId = LayoutTestUtil.addPortletToLayout(
+				stagingLayout, rootPortletId);
+		}
+
+		Group expectedGroup = _getExpectedGroup(
+			checkStagingGroup, layoutScopeGroup, rootPortletId);
+
+		Assert.assertEquals(
+			expectedGroup.getGroupId(),
+			PortalUtil.getScopeGroupId(
+				_mockHttpServletRequest, portletId, checkStagingGroup));
+	}
+
+	private Group _liveLayoutScopeGroup;
+	private final MockHttpServletRequest _mockHttpServletRequest =
+		new MockHttpServletRequest();
+	private Group _stagingLayoutScopeGroup;
+
+}


### PR DESCRIPTION
Hi @jonathanmccann,

Sorry for the late reply, here are the integration tests for LPS-150134.
I did some refactoring to reuse existing tests, the **StagingGetScopeGroupIdTest** class is meant to test the current fix.

I used the @Ignore annotation, because these tests don't pass right now, also they don't pass after your fix either.
I tend to think that **checkStagingGroup** should be used to decide if we want the staging or the live group, when the portlet is not staged. Though it's challenging to figure out the original intention for this method.

Could you please let me know if you agree with these tests?
Mostly the logic in **_getExpectedGroup** is relevant here.

**Note:**
I haven't created a test for the use case when the live layout doesn't exist yet / doesn't have a scopeGroup yet, it's in my ToDo.

cc @gaborlovasdotcom
 
