### PR TITLE
LPS-155127 Remove hyperlink from cancel button

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
@@ -466,7 +466,7 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 			<aui:button-row>
 				<aui:button type="submit" value="export" />
 
-				<aui:button href="<%= currentURL %>" type="cancel" />
+				<aui:button type="cancel" />
 			</aui:button-row>
 		</aui:form>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155127

Issue:
When clicking on the Cancel button of Export/Import modal, the modal does not go away. 

Solution:
Removing the hyperlink to the currentURL fixes this issue. The modal is deleted and the Cancel button works as intended.

Let me know if there are any questions or comments about this.
Thank you.