### PR TITLE
[TS] LPS-156202

### DIFF
--- a/modules/apps/expando/expando-export-import/src/main/java/com/liferay/expando/exportimport/internal/staged/model/repository/StagedExpandoColumnStagedModelRepository.java
+++ b/modules/apps/expando/expando-export-import/src/main/java/com/liferay/expando/exportimport/internal/staged/model/repository/StagedExpandoColumnStagedModelRepository.java
@@ -66,10 +66,16 @@ public class StagedExpandoColumnStagedModelRepository
 			StagedExpandoColumn stagedExpandoColumn)
 		throws PortalException {
 
+		long columnId = stagedExpandoColumn.getColumnId();
+
+		stagedExpandoColumn.setColumnId(0);
+
 		ExpandoColumn expandoColumn = _expandoColumnLocalService.addColumn(
 			stagedExpandoColumn.getTableId(), stagedExpandoColumn.getName(),
 			stagedExpandoColumn.getType(),
 			stagedExpandoColumn.getDefaultValue());
+
+		stagedExpandoColumn.setColumnId(columnId);
 
 		expandoColumn = _expandoColumnLocalService.updateTypeSettings(
 			expandoColumn.getColumnId(), stagedExpandoColumn.getTypeSettings());

--- a/modules/apps/expando/expando-test/src/testIntegration/java/com/liferay/expando/exportimport/test/StagedExpandoColumnStagedModelRepositoryTest.java
+++ b/modules/apps/expando/expando-test/src/testIntegration/java/com/liferay/expando/exportimport/test/StagedExpandoColumnStagedModelRepositoryTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.expando.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.model.adapter.StagedExpandoColumn;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.adapter.ModelAdapterUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.expando.util.test.ExpandoTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@RunWith(Arquillian.class)
+public class StagedExpandoColumnStagedModelRepositoryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_expandoTable = ExpandoTestUtil.addTable(
+			PortalUtil.getClassNameId(User.class), "CUSTOM_FIELDS");
+
+		_stagedModelRepository =
+			(StagedModelRepository<StagedExpandoColumn>)
+				StagedModelRepositoryRegistryUtil.getStagedModelRepository(
+					StagedExpandoColumn.class.getName());
+	}
+
+	@Test
+	public void testExportImportKeepsCheckboxValues() throws Exception {
+		ExpandoColumn originalExpandoColumn =
+			_expandoColumnLocalService.addColumn(
+				_expandoTable.getTableId(), RandomTestUtil.randomString(),
+				ExpandoColumnConstants.STRING, RandomTestUtil.randomString());
+
+		StagedExpandoColumn stagedExpandoColumn = ModelAdapterUtil.adapt(
+			originalExpandoColumn, ExpandoColumn.class,
+			StagedExpandoColumn.class);
+
+		_expandoColumnLocalService.deleteColumn(
+			originalExpandoColumn.getColumnId());
+
+		StagedExpandoColumn importedStagedExpandoColumn =
+			_stagedModelRepository.addStagedModel(null, stagedExpandoColumn);
+
+		ExpandoColumn importedExpandoColumn =
+			_expandoColumnLocalService.getExpandoColumn(
+				importedStagedExpandoColumn.getColumnId());
+
+		Assert.assertEquals(
+			originalExpandoColumn.getDefaultData(),
+			importedExpandoColumn.getDefaultData());
+	}
+
+	@Inject
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
+	@DeleteAfterTestRun
+	private ExpandoTable _expandoTable;
+
+	private StagedModelRepository<StagedExpandoColumn> _stagedModelRepository;
+
+}


### PR DESCRIPTION
Motivation
=======
ExpandoColumns are losing their defaultData if imported to an instance where they don't already exist
[Link to ticket](https://issues.liferay.com/browse/LPS-156202)

Proposed Solution
========
* Validation of the defaultData can't happen without the column already being present (https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoValueImpl.java#L92)
* We can skip the validation by removing the imported stagedExpandoColumn's columnId
* By skipping the validation we can extract the defaultData

Steps to Verify:
----------------
1. Open the menu on the upper right --> Control Panel --> Custom Fields
1. Select User and create a checkbox custom field (set value as "test")
1. Go back to Custom Fields and click on the 3 dot menu on the upper right
1. Select "Export" and download the lar file
1. Remove the previously created User custom field
1. Go back to Custom Fields and click on the 3 dot menu on the upper right
1. Import the LAR file
1. Check the imported custom field value

**Expected behaviour:** The custom field value should be "test"
**Actual behaviour:** The value of the custom field is missing
