### PR TITLE
LPS-157427

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
@@ -90,7 +90,7 @@
 		boolean showPortletDataInput = MapUtil.getBoolean(parameterMap, PortletDataHandlerKeys.PORTLET_DATA + StringPool.UNDERLINE + portlet.getPortletId(), portletDataHandler.isPublishToLiveByDefault()) || MapUtil.getBoolean(parameterMap, PortletDataHandlerKeys.PORTLET_DATA_ALL);
 	%>
 
-		<li class="tree-item">
+		<li class="tree-item <%= ((exportModelCount > 0) || showAllPortlets) ? StringPool.BLANK : "deletions" %>">
 			<liferay-staging:checkbox
 				checked="<%= showPortletDataInput %>"
 				deletions="<%= modelDeletionCount %>"


### PR DESCRIPTION
Assign the `deletions` class to the portlet if the only reason it appears in the list is because there are deletions to be published. This will cause its visibility to be toggled whenever the user toggles the "Replicate Individual Deletions" option.

https://issues.liferay.com/browse/LPS-157427