### PR TITLE
[TS] LPS-157852 GroupLocalServiceUtil.validateRemote is not correctly validating that the remote group belongs to the same company than the user

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -99,7 +99,6 @@ import com.liferay.portal.kernel.security.permission.RolePermissions;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
@@ -5099,9 +5098,19 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			// Ping the remote host and verify that the remote group exists in
 			// the same company as the remote user
 
+			Class<?> groupServiceUtilClass = null;
+
+			try {
+				groupServiceUtilClass = Class.forName(
+					"com.liferay.portal.kernel.service.GroupServiceUtil");
+			}
+			catch (ClassNotFoundException classNotFoundException) {
+				throw new SystemException(classNotFoundException);
+			}
+
 			try {
 				MethodKey methodKey = new MethodKey(
-					GroupServiceUtil.class, "checkRemoteStagingGroup",
+					groupServiceUtilClass, "checkRemoteStagingGroup",
 					_CHECK_REMOTE_STAGING_GROUP_PARAMETER_TYPES);
 
 				MethodHandler methodHandler = new MethodHandler(

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -99,7 +99,7 @@ import com.liferay.portal.kernel.security.permission.RolePermissions;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupService;
+import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
@@ -5101,7 +5101,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 			try {
 				MethodKey methodKey = new MethodKey(
-					GroupService.class, "checkRemoteStagingGroup",
+					GroupServiceUtil.class, "checkRemoteStagingGroup",
 					_CHECK_REMOTE_STAGING_GROUP_PARAMETER_TYPES);
 
 				MethodHandler methodHandler = new MethodHandler(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-157852

The method `GroupLocalServiceUtil.validateRemote` is used from staging logic.

This regression was caused by [LPS-89294](https://issues.liferay.com/browse/LPS-89294), this commit https://github.com/brianchandotcom/liferay-portal/pull/83605/commits/8c2efa6b5ddeb718207f2ff1e382886d3acea8c6#diff-809c64f8ed9e550f63935bdd9fc3d34e1780651d80004c804c6a7ea4806c185bR5118 started to use GroupService.class to call the remote server, but this is not accepted by TunnelServlet, see https://github.com/liferay/liferay-portal/blob/d7eaa1436b2006f79901d43bced1579d3089dd03/portal-impl/src/com/liferay/portal/servlet/TunnelServlet.java#L161-L172 so the call is silently ignored and no validations are executed in the remote server.

If you apply [LPS-157845](https://issues.liferay.com/browse/LPS-157845) correction and you activate the warn log level of com.liferay.portal.servlet.TunnelServlet you will also see a warn exception saying "Invalid request interface com.liferay.portal.kernel.service.GroupService"

The correction is very simple, just replacing `GroupService.class` with `GroupServiceUtil.class` in the TunnelUtil.invoke call, see commit https://github.com/liferay-staging/liferay-portal/commit/bf793d9623c0d786d7925cce8b3023bf8e900e46

The problem here is the JavaServiceUtilCheck SF rule doesn't allow importing any *ServiceUtil class, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/java_service_util_check.markdown

To solve this issue the only idea is to avoid importing the class and load it using `Class.forName`, see https://github.com/liferay-staging/liferay-portal/commit/62dd83f4f3ceeecae467362c0e38d254a485500d it is a bit ugly but I don't have any other idea.

Let me know if I should change anything.

Regards,
Jorge