### PR TITLE
LPS-158430 Use InetAddressUtil#getInetAddressByName to make use of dns.security.address.timeout.seconds

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1194,13 +1194,17 @@ public class LayoutReferencesExportImportContentProcessor
 				}
 			}
 
-			if ((uri != null) &&
-				InetAddressUtil.isLocalInetAddress(
-					InetAddress.getByName(uri.getHost()))) {
+			if (uri != null) {
+				InetAddress inetAddress = InetAddressUtil.getInetAddressByName(
+					uri.getHost());
 
-				return StringBundler.concat(
-					uri.getScheme(), "://", uri.getHost(), StringPool.COLON,
-					uri.getPort());
+				if ((inetAddress != null) &&
+					InetAddressUtil.isLocalInetAddress(inetAddress)) {
+
+					return StringBundler.concat(
+						uri.getScheme(), "://", uri.getHost(), StringPool.COLON,
+						uri.getPort());
+				}
 			}
 		}
 		catch (UnknownHostException unknownHostException) {


### PR DESCRIPTION
Motivation
=======
[LPS-158430](https://issues.liferay.com/browse/LPS-158430)
If a Web Content or a Document has an HTML field or several HTML fields with a considerable amount of links to external sites, these DNS resolution times can add up to several seconds or even more than one minute. While editing such content, this validation can also time out the update request if the `InetAddress` lookups are delayed for too long. Having `dns.security.address.timeout.seconds` time out the long `InetAddress` lookups can be cut short by manual configuration.

Proposed Solution
========
Use `InetAddressUtil#getInetAddressByName`, which has build in usage of `dns.security.address.timeout.seconds` instead of `InetAddress#getByName`

Steps to Verify
========
I don't think we can easily verify this improvement, the logic was agreed upon by [PTR-3171](https://issues.liferay.com/browse/PTR-3171)

Note
========
This PR might also need a review from liferay-echo