### PR TITLE
[TS] LPP-46108 > LPS-159985 JavaScript set in the site template is not properly propagated

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -2887,7 +2887,9 @@ public class LayoutStagedModelDataHandler
 				layoutTypePortlet.getTypeSettingsProperties();
 
 			UnicodeProperties newTypeSettingsUnicodeProperties =
-				UnicodePropertiesBuilder.fastLoad(
+				UnicodePropertiesBuilder.create(
+					prototypeTypeSettingsUnicodeProperties.isSafe()
+				).fastLoad(
 					prototypeTypeSettingsUnicodeProperties.toString()
 				).build();
 


### PR DESCRIPTION
Dear Team ,

You can find every details on the LPS: https://issues.liferay.com/browse/LPS-159985


The fix:
UnicodePropertiesBuilder.create(
					prototypeTypeSettingsUnicodeProperties.isSafe()
				).fastLoad(;
Because when LayoutStagedModelDataHandler copies to newTypeSettingsUnicodeProperties , it misses setting the _safe value in UnicodeProperties therefore this is causing this error. This solution is passed in my internal team's review.

Please help me review this ticket. 
Thanks

cc: @chileces @holatuwol 