### PR TITLE
LPS-161393 Include the 'doAsUserId' so the session tree click is saved to the correct user's portal preferences

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/js/layouts_tree_state.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/js/layouts_tree_state.js
@@ -398,6 +398,7 @@ AUI.add(
 					const root = host.get('root');
 
 					data = {
+						doAsUserId: themeDisplay.getDoAsUserIdEncoded(),
 						groupId: root.groupId,
 						privateLayout: root.privateLayout,
 						recursive: true,


### PR DESCRIPTION
I wasn't sure who owned this module or file but since it was discovered utilizing Staging I thought it made sense to start with your team. Please let me know your thoughts or if there is a better team to review this change.