### PR TITLE
[TS] LPS-161743 NPE in ExportImportHelperImpl.validateMissingReference when className doesn't have a StagedModelDataHandler

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
@@ -1498,7 +1498,8 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
 				className);
 
-		if (!stagedModelDataHandler.validateReference(
+		if ((stagedModelDataHandler == null) ||
+			!stagedModelDataHandler.validateReference(
 				portletDataContext, element)) {
 
 			MissingReference missingReference = new MissingReference(element);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-161743

A NPE in ExportImportHelperImpl.validateMissingReference when className doesn't have a StagedModelDataHandler
This can be caused when you have a custom module that adds missing references to classNames that doesn't have a valid StagedModelDataHandler or it is not correctly deployed.

Our customer is reproducing this in a portlet with its own ExportImportPortletPreferencesProcessor that exports a missing reference. If we avoid the NPE, the customer will have a controlled error in the user interface that will be easier to understand than current "An unexpected error occurred" message