### PR TITLE
LPS-157420

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java
@@ -100,6 +100,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1067,6 +1068,9 @@ public class PortletExportControllerImpl implements PortletExportController {
 			Element exportDataRootElement =
 				portletDataContext.getExportDataRootElement();
 
+			Set<String> oldScopedPrimaryKeys = new HashSet<>(
+				portletDataContext.getScopedPrimaryKeys());
+
 			try {
 				portletDataContext.clearScopedPrimaryKeys();
 
@@ -1102,6 +1106,8 @@ public class PortletExportControllerImpl implements PortletExportController {
 			finally {
 				portletDataContext.setExportDataRootElement(
 					exportDataRootElement);
+
+				portletDataContext.addScopedPrimaryKeys(oldScopedPrimaryKeys);
 			}
 		}
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -124,6 +124,7 @@ import java.io.Serializable;
 import java.sql.Timestamp;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -456,6 +457,11 @@ public class PortletDataContextImpl implements PortletDataContext {
 		}
 
 		return value;
+	}
+
+	@Override
+	public void addScopedPrimaryKeys(Collection<String> scopedPrimaryKeys) {
+		_scopedPrimaryKeys.addAll(scopedPrimaryKeys);
 	}
 
 	@Override
@@ -1134,6 +1140,10 @@ public class PortletDataContextImpl implements PortletDataContext {
 	@Override
 	public String getRootPortletId() {
 		return _rootPortletId;
+	}
+
+	public Set<String> getScopedPrimaryKeys() {
+		return _scopedPrimaryKeys;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataContext.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataContext.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.zip.ZipWriter;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -128,6 +129,8 @@ public interface PortletDataContext extends Serializable {
 		String referenceType, boolean missing);
 
 	public boolean addScopedPrimaryKey(Class<?> clazz, String primaryKey);
+
+	public void addScopedPrimaryKeys(Collection<String> scopedPrimaryKeys);
 
 	public void addZipEntry(String path, byte[] bytes);
 
@@ -289,6 +292,8 @@ public interface PortletDataContext extends Serializable {
 		StagedModel parentStagedModel, Class<?> clazz);
 
 	public String getRootPortletId();
+
+	public Set<String> getScopedPrimaryKeys();
 
 	public long getScopeGroupId();
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0


### PR DESCRIPTION
Ticket: [LPS-157420](https://issues.liferay.com/browse/LPS-157420), Also see [LPS-162526](https://issues.liferay.com/browse/LPS-162526) which is the same issue.

We only want the "clearing" of the scopedPrimaryKeys to be temporary while we export the PortletPreferences. When we are finished, we need to restore them. Otherwise, we risk an infinite loop into a StackOverflowError later on down the line if there is a circular reference involving a Layout with a PortletPreferences, because every time the Layout is imported, the PortletPreferences will also be imported and clear the scopedPrimaryKeys. The scopedPrimaryKeys are how we prevent the infinite loop from occurring (see [this line](https://github.com/liferay/liferay-portal/blob/5329fcdb461f56b6921a56252983255a7ab0076c/portal-kernel/src/com/liferay/exportimport/kernel/lar/BaseStagedModelDataHandler.java#L83-L85), where we return early if we detect that the scopedPrimaryKey of the asset to be imported was already stored).