### PR TITLE
LPS-163142 Keep the missing flag even though the referenced element was exported by another entity, otherwise we won't be able to resolve the references in portlet.xml/portlet-data.xml

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -422,11 +422,11 @@ public class PortletDataContextImpl implements PortletDataContext {
 		String referenceKey = _getReferenceKey(classedModel);
 
 		if (missing) {
+			referenceElement.addAttribute("missing", Boolean.TRUE.toString());
+
 			if (_references.contains(referenceKey)) {
 				return referenceElement;
 			}
-
-			referenceElement.addAttribute("missing", Boolean.TRUE.toString());
 
 			if (!_missingReferences.contains(referenceKey)) {
 				_missingReferences.add(referenceKey);


### PR DESCRIPTION
Hi @mbowerman, @vendeltoreki,

This is a small change, but I'd appreciate if you guys could take a look at it.

I'll ask @gaborlovasdotcom to QA this in the meantime.

Best,
Tamas  