### PR TITLE
LPS-167905

### DIFF
--- a/modules/apps/asset/asset-display-page-service/build.gradle
+++ b/modules/apps/asset/asset-display-page-service/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-display-page-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:portal:portal-aop-api")
+	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")
 	compileOnly project(":core:petra:petra-function")


### PR DESCRIPTION
## Root cause summary

Display page templates reference both a layout (the page that is used to handle rendering the display page template) and an asset. While this is ordinarily not problematic, display page templates are backed by content pages, which can reference a content through mapped fields.

This means that there is a potential for a circular reference: a display page template can be backed by a content page with a mapped field that points to a piece of content that in turn uses the same display page template.

Looking at the code for how AssetDisplayPageEntry models are exported, Liferay's import and export process attempts to break the potential for a circular reference by only having one reference: the reference to the layout.

https://github.com/liferay/liferay-portal/blob/7.4.3.49-ga49/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java#L68-L77

Unfortunately, this solution makes it so that the staging process for display page templates is extremely sensitive to the order in which exports happen (which also influence how the import happens). As written, AssetDisplayPageEntry requires all assets need to be exported before it gets imported, but there is nothing that actually enforces this at a code level because there is no reference to the asset.

## Steps to reproduce

Please see https://issues.liferay.com/browse/LPS-167905

## Steps to reproduce explained

The steps to reproduce introduce an ordering issue by introducing an asset into staging that is exported before web content and causes display page templates to be imported before web content as well: fragment collection resources when they (erroneously?) have a display page template.

In doing this, the export process creates a manifest which guarantees that web content for a mapped field will be imported too late, causing Liferay to not know what the proper primary key is for the web content, causing a duplicate exception when importing the display page template.

## Solution notes

The current solution provided in this pull request adds code to export the referenced asset anyway, ignoring any potential issues with circular references, and the export succeeds.

However, I don't know if this is because circular references are actually okay in staging, or if I'm introducing a potential issue.

**Note**: The solution is unable to fetch AssetEntry or leverage any of the related staging utility methods for an AssetEntry, because fragment collection references do not have AssetEntry rows in the database. 