### PR TITLE
LPS-170348 Store Changeset PortletPreferences against the correct plid

### DIFF
--- a/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/data/handler/ChangesetPortletDataHandler.java
+++ b/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/data/handler/ChangesetPortletDataHandler.java
@@ -212,13 +212,20 @@ public class ChangesetPortletDataHandler extends BasePortletDataHandler {
 
 		List<Element> entityTypeElements = importDataRootElement.elements();
 
-		for (Element entityTypeElement : entityTypeElements) {
-			List<Element> entityElements = entityTypeElement.elements();
+		long originalPlid = portletDataContext.getPlid();
 
-			for (Element entityElement : entityElements) {
-				StagedModelDataHandlerUtil.importStagedModel(
-					portletDataContext, entityElement);
+		try {
+			for (Element entityTypeElement : entityTypeElements) {
+				List<Element> entityElements = entityTypeElement.elements();
+
+				for (Element entityElement : entityElements) {
+					StagedModelDataHandlerUtil.importStagedModel(
+						portletDataContext, entityElement);
+				}
 			}
+		}
+		finally {
+			portletDataContext.setPlid(originalPlid);
 		}
 
 		String[] portletResourceNames = _getPortletResourceNames(


### PR DESCRIPTION
Ticket: [LPS-170348](https://issues.liferay.com/browse/LPS-170348)

This fixes an issue where the portletPreferences for the Changeset Portlet can get stored against the wrong plid. I actually wasn't sure how to test this issue in a user-visible way in master because the behavior in master is that we don't store empty PortletPreferences in the database at all (which is different from 7.3 and 7.2), and I wasn't sure how to make it generate a non-empty PortletPreferences for the Changeset Portlet.

I did test this change in 7.2 and verified that it fixed a user-visible bug there, which you can read in the Steps to Reproduce of [LPS-170348](https://issues.liferay.com/browse/LPS-170348).