### PR TITLE
LPS-162572 Set exportReferencedContent to true

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
@@ -101,7 +101,7 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 			_dlReferencesExportImportContentProcessor.
 				replaceExportContentReferences(
 					portletDataContext, layoutPageTemplateStructureRel,
-					layoutPageTemplateStructureRel.getData(), false, false);
+					layoutPageTemplateStructureRel.getData(), true, false);
 
 		data =
 			_layoutPageTemplateStructureRelReferencesExportImportContentProcessor.


### PR DESCRIPTION
The exportReferencedContent boolean was set false by LPS-170032. The true value allows the DataHandler class to export the contents, so the references won't miss in the remote live site. This fix does not affect the LPS-170032 issue.