### PR TITLE
[TS] LPS-173799 Use the file name to avoid showing the imports as 'Untitled'

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCActionCommand.java
@@ -50,8 +50,10 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.InputStream;
@@ -313,10 +315,17 @@ public class ImportLayoutsMVCActionCommand extends BaseMVCActionCommand {
 					actionRequest.getParameterMap(), themeDisplay.getLocale(),
 					themeDisplay.getTimeZone());
 
+		String name = GetterUtil.getString(
+			importLayoutSettingsMap.get("portletId"));
+
+		if (Validator.isNull(name)) {
+			name = fileName;
+		}
+
 		ExportImportConfiguration exportImportConfiguration =
 			_exportImportConfigurationLocalService.
 				addDraftExportImportConfiguration(
-					themeDisplay.getUserId(),
+					themeDisplay.getUserId(), name,
 					ExportImportConfigurationConstants.TYPE_IMPORT_LAYOUT,
 					importLayoutSettingsMap);
 


### PR DESCRIPTION
These changes maintain the previous behavior (https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/exportimport/service/impl/ExportImportConfigurationLocalServiceImpl.java#L67-L70) but utilizes the file name if the name is null. This will avoid showing the import process as "Untitled".

Please let me know if there are any questions or concerns.