### PR TITLE
[TS] LPS-172553 staging is available for sites with a name of a specific length

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -386,7 +386,20 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			friendlyURL);
 
 		if (staging) {
-			groupKey = groupKey.concat("-staging");
+			String stagingGroupKeyAddition = "-staging";
+
+			if (groupKey.length() <
+					(GroupConstants.GROUP_KEY_MAX_LENGTH -
+						stagingGroupKeyAddition.length())) {
+
+				groupKey = groupKey.concat(stagingGroupKeyAddition);
+			}
+			else {
+				groupKey = groupKey.substring(0, 139);
+				stagingGroupKeyAddition = "..." + stagingGroupKeyAddition;
+
+				groupKey = groupKey.concat(stagingGroupKeyAddition);
+			}
 
 			for (Map.Entry<Locale, String> entry : nameMap.entrySet()) {
 				String name = entry.getValue();

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -387,18 +387,27 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		if (staging) {
 			String stagingGroupKeyAddition = "-staging";
+			int groupKeyMaxLength = ModelHintsUtil.getMaxLength(
+				Group.class.getName(), "groupKey");
 
 			if (groupKey.length() <
-					(GroupConstants.GROUP_KEY_MAX_LENGTH -
-						stagingGroupKeyAddition.length())) {
+					(groupKeyMaxLength - stagingGroupKeyAddition.length())) {
 
 				groupKey = groupKey.concat(stagingGroupKeyAddition);
 			}
 			else {
-				groupKey = groupKey.substring(0, 139);
-				stagingGroupKeyAddition = "..." + stagingGroupKeyAddition;
+				int counter = 1;
 
-				groupKey = groupKey.concat(stagingGroupKeyAddition);
+				groupKey = _createLongStagingGroupKey(
+					groupKey, stagingGroupKeyAddition, groupKeyMaxLength,
+					counter);
+
+				while (fetchGroup(user.getCompanyId(), groupKey) != null) {
+					counter++;
+					groupKey = _createLongStagingGroupKey(
+						groupKey, stagingGroupKeyAddition, groupKeyMaxLength,
+						counter);
+				}
 			}
 
 			for (Map.Entry<Locale, String> entry : nameMap.entrySet()) {
@@ -5242,6 +5251,20 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	}
 
 	protected File publicLARFile;
+
+	private String _createLongStagingGroupKey(
+		String groupKey, String stagingGroupKeyAddition, int groupKeyMaxLength,
+		int counter) {
+
+		String createdStagingGroupKeyAddition =
+			counter + stagingGroupKeyAddition;
+
+		groupKey = groupKey.substring(
+			0, groupKeyMaxLength - createdStagingGroupKeyAddition.length());
+		groupKey = groupKey.concat(createdStagingGroupKeyAddition);
+
+		return groupKey;
+	}
 
 	private Collection<Group> _filterGroups(
 		String actionId, Collection<Group> groups) {

--- a/portal-kernel/src/com/liferay/portal/kernel/model/GroupConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/GroupConstants.java
@@ -43,6 +43,8 @@ public class GroupConstants {
 
 	public static final String GLOBAL_FRIENDLY_URL = "/global";
 
+	public static final int GROUP_KEY_MAX_LENGTH = 150;
+
 	public static final String GUEST = "Guest";
 
 	public static final int MEMBERSHIP_RESTRICTION_TO_PARENT_SITE_MEMBERS = 1;

--- a/portal-kernel/src/com/liferay/portal/kernel/model/GroupConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/GroupConstants.java
@@ -43,8 +43,6 @@ public class GroupConstants {
 
 	public static final String GLOBAL_FRIENDLY_URL = "/global";
 
-	public static final int GROUP_KEY_MAX_LENGTH = 150;
-
 	public static final String GUEST = "Guest";
 
 	public static final int MEMBERSHIP_RESTRICTION_TO_PARENT_SITE_MEMBERS = 1;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-172553
Thank you!

---------
**Reproduction Steps:**

1. Create a new site with this name: "The very important site that deals with very complex stuff no one has a clue about but we don't want to think about no more in the upcoming weeks"
2. Try to enable local staging.

**Expected outcome:** Staging should be activated for the page.
**Actual outcome:** Staging can not be activated as the group key would be out of its limits

Solution:
As discussed on [PTR-3649](https://issues.liferay.com/browse/PTR-3649) when creating a group key for the staged site with a specific length, it will be made up from a shortened site name and the postfix within the character limit.