### PR TITLE
[TS] LPS-174381 Date range is reset when clicking 'Refresh Counts'. If there is a range available in the request then prefer that one

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/content/init.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/content/init.jsp
@@ -50,7 +50,12 @@ Map<String, String[]> parameterMap = Collections.emptyMap();
 ExportImportConfiguration exportImportConfiguration = ExportImportConfigurationLocalServiceUtil.fetchExportImportConfiguration(exportImportConfigurationId);
 
 if (exportImportConfiguration != null) {
-	dateRange = ExportImportDateUtil.getDateRange(exportImportConfiguration);
+	if (Validator.isNotNull(request.getParameter("startDate")) && Validator.isNotNull(request.getParameter("endDate"))) {
+		dateRange = ExportImportDateUtil.getDateRange(renderRequest, exportGroupId, privateLayout, 0, null, defaultRange);
+	}
+	else {
+		dateRange = ExportImportDateUtil.getDateRange(exportImportConfiguration);
+	}
 
 	settingsMap = exportImportConfiguration.getSettingsMap();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174381

This one was a little tricky so please let me know if you see a better way to resolve it.

The issue stems from the fact that clicking "Refresh Counts" reloads the page but we then still fetch information from the _exportImportConfiguration_. This causes a mismatch between what is being displayed in the UI and what is being sent back to the server. In these changes I check to see if the request object is populated, which only happens after a refresh, and if so then get the date range from the request instead of the old _exportImportConfiguration_.

Let me know if there are any questions or if you see a different way around this issue.