### PR TITLE
LPS-168752 HR_431 Accessibility improvements for the Export/Import modal

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
@@ -17,9 +17,11 @@
 <%@ include file="/deletions/init.jsp" %>
 
 <c:if test="<%= cmd.equals(Constants.EXPORT) || cmd.equals(Constants.IMPORT) || cmd.equals(Constants.PUBLISH) %>">
-	<aui:fieldset cssClass="options-group" markupView="lexicon">
+	<div aria-labelledby="<portlet:namespace />deletions" class="options-group" role="group">
 		<clay:sheet-section>
-			<span class="sheet-subtitle"><liferay-ui:message key="deletions" /></span>
+			<span class="sheet-subtitle" id="<portlet:namespace />deletions">
+				<liferay-ui:message key="deletions" />
+			</span>
 
 			<c:if test="<%= !cmd.equals(Constants.EXPORT) %>">
 				<liferay-staging:checkbox
@@ -44,5 +46,5 @@
 				name="<%= PortletDataHandlerKeys.DELETIONS %>"
 			/>
 		</clay:sheet-section>
-	</aui:fieldset>
+	</div>
 </c:if>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
@@ -19,7 +19,7 @@
 <c:if test="<%= cmd.equals(Constants.EXPORT) || cmd.equals(Constants.IMPORT) || cmd.equals(Constants.PUBLISH) %>">
 	<aui:fieldset cssClass="options-group" markupView="lexicon">
 		<clay:sheet-section>
-			<h3 class="sheet-subtitle"><liferay-ui:message key="deletions" /></h3>
+			<span class="sheet-subtitle"><liferay-ui:message key="deletions" /></span>
 
 			<c:if test="<%= !cmd.equals(Constants.EXPORT) %>">
 				<liferay-staging:checkbox

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/permissions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/permissions/page.jsp
@@ -18,7 +18,7 @@
 
 <aui:fieldset cssClass="options-group" markupView="lexicon">
 	<clay:sheet-section>
-		<h3 class="sheet-subtitle"><liferay-ui:message key="permissions" /></h3>
+		<span class="sheet-subtitle"><liferay-ui:message key="permissions" /></span>
 
 		<%
 		ExportImportServiceConfiguration exportImportServiceConfiguration = ConfigurationProviderUtil.getSystemConfiguration(ExportImportServiceConfiguration.class);

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/permissions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/permissions/page.jsp
@@ -16,9 +16,11 @@
 
 <%@ include file="/permissions/init.jsp" %>
 
-<aui:fieldset cssClass="options-group" markupView="lexicon">
+<div aria-labelledby="<portlet:namespace />permissions" class="options-group" role="group">
 	<clay:sheet-section>
-		<span class="sheet-subtitle"><liferay-ui:message key="permissions" /></span>
+		<span class="sheet-subtitle" id="<portlet:namespace />permissions">
+			<liferay-ui:message key="permissions" />
+		</span>
 
 		<%
 		ExportImportServiceConfiguration exportImportServiceConfiguration = ConfigurationProviderUtil.getSystemConfiguration(ExportImportServiceConfiguration.class);
@@ -32,4 +34,4 @@
 			name="<%= PortletDataHandlerKeys.PERMISSIONS %>"
 		/>
 	</clay:sheet-section>
-</aui:fieldset>
+</div>


### PR DESCRIPTION
Link to the ticket https://issues.liferay.com/browse/LPS-168752

Hi guys!

Some accessibility improvements have been done in the Export/Import modal:
- Remove all headers in the modal content. There should only be a single heading, the title of the modal (h1).
- Associate the correct label to the group to which each checkbox belongs.

Thanks in advance!