### PR TITLE
LPS 176405 fix

### DIFF
--- a/modules/apps/blogs/blogs-web/build.gradle
+++ b/modules/apps/blogs/blogs-web/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 	compileOnly project(":apps:rss:rss-taglib")
 	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":apps:social:social-bookmarks-taglib")
+	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:subscription:subscription-api")

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/item/selector/BlogsEntryItemSelectorView.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/item/selector/BlogsEntryItemSelectorView.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.staging.StagingGroupHelper;
 
 import java.io.IOException;
 
@@ -125,6 +126,9 @@ public class BlogsEntryItemSelectorView
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private StagingGroupHelper _stagingGroupHelper;
 
 	private class BlogsEntryItemDescriptor
 		implements ItemSelectorViewDescriptor.ItemDescriptor {
@@ -287,10 +291,6 @@ public class BlogsEntryItemSelectorView
 
 		@Override
 		public SearchContainer<BlogsEntry> getSearchContainer() {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)_httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
 			SearchContainer<BlogsEntry> entriesSearchContainer =
 				new SearchContainer<>(
 					(PortletRequest)_httpServletRequest.getAttribute(
@@ -304,13 +304,13 @@ public class BlogsEntryItemSelectorView
 			entriesSearchContainer.setOrderByType(getOrderByType());
 			entriesSearchContainer.setResultsAndTotal(
 				() -> _blogsEntryService.getGroupEntries(
-					themeDisplay.getScopeGroupId(),
+					_getStagingAwareGroupId(),
 					WorkflowConstants.STATUS_APPROVED,
 					entriesSearchContainer.getStart(),
 					entriesSearchContainer.getEnd(),
 					entriesSearchContainer.getOrderByComparator()),
 				_blogsEntryService.getGroupEntriesCount(
-					themeDisplay.getScopeGroupId(),
+					_getStagingAwareGroupId(),
 					WorkflowConstants.STATUS_APPROVED));
 
 			return entriesSearchContainer;
@@ -321,6 +321,22 @@ public class BlogsEntryItemSelectorView
 			return _infoItemItemSelectorCriterion.isMultiSelection();
 		}
 
+		private long _getStagingAwareGroupId() {
+			if (_groupId != null) {
+				return _groupId;
+			}
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)_httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			_groupId = _stagingGroupHelper.getStagedPortletGroupId(
+				themeDisplay.getScopeGroupId(), BlogsPortletKeys.BLOGS);
+
+			return _groupId;
+		}
+
+		private Long _groupId;
 		private HttpServletRequest _httpServletRequest;
 		private final InfoItemItemSelectorCriterion
 			_infoItemItemSelectorCriterion;

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -549,22 +548,10 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			return _groupId;
 		}
 
-		long groupId = _themeDisplay.getScopeGroupId();
+		_groupId = _stagingGroupHelper.getStagedPortletGroupId(
+			_themeDisplay.getScopeGroupId(), DLPortletKeys.DOCUMENT_LIBRARY);
 
-		if (_stagingGroupHelper.isStagingGroup(groupId) &&
-			!_stagingGroupHelper.isStagedPortlet(
-				groupId, DLPortletKeys.DOCUMENT_LIBRARY)) {
-
-			Group group = _stagingGroupHelper.fetchLiveGroup(groupId);
-
-			if (group != null) {
-				groupId = group.getGroupId();
-			}
-		}
-
-		_groupId = groupId;
-
-		return groupId;
+		return _groupId;
 	}
 
 	private int[] _getStartAndEnd() {

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -444,7 +444,8 @@ public class JournalContentDisplayContext {
 		itemSelectorCriterion.setStatus(WorkflowConstants.STATUS_ANY);
 
 		return _itemSelector.getItemSelectorURL(
-			requestBackedPortletURLFactory,
+			requestBackedPortletURLFactory, _getGroup(),
+			_themeDisplay.getScopeGroupId(),
 			liferayRenderResponse.getNamespace() + "selectedItem",
 			itemSelectorCriterion);
 	}
@@ -1041,6 +1042,24 @@ public class JournalContentDisplayContext {
 		return DDMTemplateLocalServiceUtil.fetchTemplate(
 			article.getGroupId(), _ddmStructureClassNameId, ddmTemplateKey,
 			true);
+	}
+
+	private Group _getGroup() {
+		Group group = _themeDisplay.getScopeGroup();
+
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (stagingGroupHelper.isLocalStagingGroup(group.getGroupId()) &&
+			!stagingGroupHelper.isStagedPortlet(
+				group.getGroupId(), JournalPortletKeys.JOURNAL)) {
+
+			Group scopeGroup = _themeDisplay.getScopeGroup();
+
+			group = scopeGroup.getLiveGroup();
+		}
+
+		return group;
 	}
 
 	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -406,21 +406,11 @@ public class JournalContentDisplayContext {
 	}
 
 	public long getGroupId() {
-		long groupId = _themeDisplay.getScopeGroupId();
-
 		StagingGroupHelper stagingGroupHelper =
 			StagingGroupHelperUtil.getStagingGroupHelper();
 
-		if (stagingGroupHelper.isLocalStagingGroup(groupId) &&
-			!stagingGroupHelper.isStagedPortlet(
-				groupId, JournalPortletKeys.JOURNAL)) {
-
-			Group scopeGroup = _themeDisplay.getScopeGroup();
-
-			groupId = scopeGroup.getLiveGroupId();
-		}
-
-		return groupId;
+		return stagingGroupHelper.getStagedPortletGroupId(
+			_themeDisplay.getScopeGroupId(), JournalPortletKeys.JOURNAL);
 	}
 
 	public PortletURL getItemSelectorURL() {
@@ -1045,21 +1035,11 @@ public class JournalContentDisplayContext {
 	}
 
 	private Group _getGroup() {
-		Group group = _themeDisplay.getScopeGroup();
-
 		StagingGroupHelper stagingGroupHelper =
 			StagingGroupHelperUtil.getStagingGroupHelper();
 
-		if (stagingGroupHelper.isLocalStagingGroup(group.getGroupId()) &&
-			!stagingGroupHelper.isStagedPortlet(
-				group.getGroupId(), JournalPortletKeys.JOURNAL)) {
-
-			Group scopeGroup = _themeDisplay.getScopeGroup();
-
-			group = scopeGroup.getLiveGroup();
-		}
-
-		return group;
+		return stagingGroupHelper.getStagedPortletGroup(
+			_themeDisplay.getScopeGroup(), JournalPortletKeys.JOURNAL);
 	}
 
 	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleClassTypeReader.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleClassTypeReader.java
@@ -17,7 +17,6 @@ package com.liferay.journal.web.internal.asset.model;
 import com.liferay.asset.kernel.model.BaseDDMStructureClassTypeReader;
 import com.liferay.asset.kernel.model.ClassType;
 import com.liferay.journal.constants.JournalPortletKeys;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.StagingGroupHelperUtil;
 
@@ -50,15 +49,8 @@ public class JournalArticleClassTypeReader
 		groupIds = groupIds.clone();
 
 		for (int i = 0; i < groupIds.length; i++) {
-			if (stagingGroupHelper.isLocalStagingGroup(groupIds[i]) &&
-				!stagingGroupHelper.isStagedPortlet(
-					groupIds[i], JournalPortletKeys.JOURNAL)) {
-
-				Group group = stagingGroupHelper.fetchLocalLiveGroup(
-					groupIds[i]);
-
-				groupIds[i] = group.getGroupId();
-			}
+			groupIds[i] = stagingGroupHelper.getStagedPortletGroupId(
+				groupIds[i], JournalPortletKeys.JOURNAL);
 		}
 
 		return groupIds;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.staging.StagingGroupHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,7 +99,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		String itemSelectedEventName,
 		JournalArticleItemSelectorView journalArticleItemSelectorView,
 		JournalWebConfiguration journalWebConfiguration, PortletURL portletURL,
-		boolean search) {
+		boolean search, StagingGroupHelper stagingGroupHelper) {
 
 		_httpServletRequest = httpServletRequest;
 		_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
@@ -107,6 +108,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		_journalWebConfiguration = journalWebConfiguration;
 		_portletURL = portletURL;
 		_search = search;
+		_stagingGroupHelper = stagingGroupHelper;
 
 		_portletRequest = (PortletRequest)httpServletRequest.getAttribute(
 			JavaConstants.JAVAX_PORTLET_REQUEST);
@@ -513,17 +515,17 @@ public class JournalArticleItemSelectorViewDisplayContext {
 
 	private long _getGroupId() {
 		return ParamUtil.getLong(
-			_portletRequest, "groupId", _themeDisplay.getScopeGroupId());
+			_portletRequest, "groupId", _getStagingAwareGroupId());
 	}
 
 	private long[] _getGroupIds() throws PortalException {
 		if (_isEverywhereScopeFilter()) {
 			return SiteConnectedGroupGroupProviderUtil.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId());
+					_getStagingAwareGroupId());
 		}
 
-		return new long[] {_themeDisplay.getScopeGroupId()};
+		return new long[] {_getStagingAwareGroupId()};
 	}
 
 	private BreadcrumbEntry _getHomeBreadcrumb() throws Exception {
@@ -593,6 +595,17 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			).buildString());
 
 		return breadcrumbEntry;
+	}
+
+	private long _getStagingAwareGroupId() {
+		if (_groupId != null) {
+			return _groupId;
+		}
+
+		_groupId = _stagingGroupHelper.getStagedPortletGroupId(
+			_themeDisplay.getScopeGroupId(), JournalPortletKeys.JOURNAL);
+
+		return _groupId;
 	}
 
 	private String _getSubtype(DDMStructure ddmStructure)
@@ -715,6 +728,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private String _displayStyle;
 	private JournalFolder _folder;
 	private Long _folderId;
+	private Long _groupId;
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoItemItemSelectorCriterion _infoItemItemSelectorCriterion;
 	private final String _itemSelectedEventName;
@@ -729,6 +743,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private final PortletURL _portletURL;
 	private final boolean _search;
 	private Boolean _searchEverywhere;
+	private final StagingGroupHelper _stagingGroupHelper;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/item/selector/JournalArticleItemSelectorView.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/item/selector/JournalArticleItemSelectorView.java
@@ -28,6 +28,7 @@ import com.liferay.journal.web.internal.constants.JournalWebConstants;
 import com.liferay.journal.web.internal.display.context.JournalArticleItemSelectorViewDisplayContext;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.staging.StagingGroupHelper;
 
 import java.io.IOException;
 
@@ -106,7 +107,8 @@ public class JournalArticleItemSelectorView
 				new JournalArticleItemSelectorViewDisplayContext(
 					(HttpServletRequest)servletRequest,
 					infoItemItemSelectorCriterion, itemSelectedEventName, this,
-					_journalWebConfiguration, portletURL, search);
+					_journalWebConfiguration, portletURL, search,
+					_stagingGroupHelper);
 
 		servletRequest.setAttribute(
 			JournalWebConstants.
@@ -143,5 +145,8 @@ public class JournalArticleItemSelectorView
 
 	@Reference(target = "(osgi.web.symbolicname=com.liferay.journal.web)")
 	private ServletContext _servletContext;
+
+	@Reference
+	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
@@ -375,7 +375,9 @@ public class ContentPageLayoutEditorDisplayContext
 
 		List<SegmentsEntry> segmentsEntries =
 			_segmentsEntryService.getSegmentsEntries(
-				_getStagingAwareGroupId(), true);
+				stagingGroupHelper.getStagedPortletGroupId(
+					getGroupId(), SegmentsPortletKeys.SEGMENTS),
+				true);
 
 		for (SegmentsEntry segmentsEntry : segmentsEntries) {
 			availableSegmentsEntries.put(
@@ -638,23 +640,6 @@ public class ContentPageLayoutEditorDisplayContext
 				"label", typeLabel
 			).build()
 		).build();
-	}
-
-	private long _getStagingAwareGroupId() {
-		long groupId = getGroupId();
-
-		if (stagingGroupHelper.isStagingGroup(groupId) &&
-			!stagingGroupHelper.isStagedPortlet(
-				groupId, SegmentsPortletKeys.SEGMENTS)) {
-
-			Group group = stagingGroupHelper.fetchLiveGroup(groupId);
-
-			if (group != null) {
-				groupId = group.getGroupId();
-			}
-		}
-
-		return groupId;
 	}
 
 	private boolean _hasEditSegmentsEntryPermission() throws Exception {

--- a/modules/apps/segments/segments-simulation-web/src/main/java/com/liferay/segments/simulation/web/internal/display/context/SegmentsSimulationDisplayContext.java
+++ b/modules/apps/segments/segments-simulation-web/src/main/java/com/liferay/segments/simulation/web/internal/display/context/SegmentsSimulationDisplayContext.java
@@ -18,7 +18,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -136,25 +135,13 @@ public class SegmentsSimulationDisplayContext {
 			return _groupId;
 		}
 
-		long groupId = _themeDisplay.getScopeGroupId();
-
 		StagingGroupHelper stagingGroupHelper =
 			StagingGroupHelperUtil.getStagingGroupHelper();
 
-		if (stagingGroupHelper.isStagingGroup(groupId) &&
-			!stagingGroupHelper.isStagedPortlet(
-				groupId, SegmentsPortletKeys.SEGMENTS)) {
+		_groupId = stagingGroupHelper.getStagedPortletGroupId(
+			_themeDisplay.getScopeGroupId(), SegmentsPortletKeys.SEGMENTS);
 
-			Group group = stagingGroupHelper.fetchLiveGroup(groupId);
-
-			if (group != null) {
-				groupId = group.getGroupId();
-			}
-		}
-
-		_groupId = groupId;
-
-		return groupId;
+		return _groupId;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/staging/staging-api/bnd.bnd
+++ b/modules/apps/staging/staging-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Staging API
 Bundle-SymbolicName: com.liferay.staging.api
-Bundle-Version: 7.0.3
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.staging,\
 	com.liferay.staging.configuration,\

--- a/modules/apps/staging/staging-api/src/main/java/com/liferay/staging/StagingGroupHelper.java
+++ b/modules/apps/staging/staging-api/src/main/java/com/liferay/staging/StagingGroupHelper.java
@@ -40,6 +40,10 @@ public interface StagingGroupHelper {
 
 	public Group fetchRemoteLiveGroup(long groupId);
 
+	public Group getStagedPortletGroup(Group group, String portletId);
+
+	public long getStagedPortletGroupId(long groupId, String portletId);
+
 	public boolean isLiveGroup(Group group);
 
 	public boolean isLiveGroup(long groupId);

--- a/modules/apps/staging/staging-api/src/main/resources/com/liferay/staging/packageinfo
+++ b/modules/apps/staging/staging-api/src/main/resources/com/liferay/staging/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.2
+version 1.2.0

--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/StagingGroupHelperImpl.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/StagingGroupHelperImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.http.GroupServiceHttp;
 import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -147,6 +148,34 @@ public class StagingGroupHelperImpl implements StagingGroupHelper {
 	@Override
 	public Group fetchRemoteLiveGroup(long groupId) {
 		return fetchRemoteLiveGroup(_groupLocalService.fetchGroup(groupId));
+	}
+
+	@Override
+	public Group getStagedPortletGroup(Group group, String portletId) {
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (stagingGroupHelper.isLocalStagingGroup(group.getGroupId()) &&
+			!stagingGroupHelper.isStagedPortlet(
+				group.getGroupId(), portletId)) {
+
+			return group.getLiveGroup();
+		}
+
+		return group;
+	}
+
+	@Override
+	public long getStagedPortletGroupId(long groupId, String portletId) {
+		if (!isStagedPortlet(groupId, portletId)) {
+			Group liveGroup = fetchLiveGroup(groupId);
+
+			if (liveGroup != null) {
+				return liveGroup.getGroupId();
+			}
+		}
+
+		return groupId;
 	}
 
 	@Override

--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/StagingGroupHelperImpl.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/StagingGroupHelperImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.http.GroupServiceHttp;
 import com.liferay.staging.StagingGroupHelper;
-import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -152,12 +151,8 @@ public class StagingGroupHelperImpl implements StagingGroupHelper {
 
 	@Override
 	public Group getStagedPortletGroup(Group group, String portletId) {
-		StagingGroupHelper stagingGroupHelper =
-			StagingGroupHelperUtil.getStagingGroupHelper();
-
-		if (stagingGroupHelper.isLocalStagingGroup(group.getGroupId()) &&
-			!stagingGroupHelper.isStagedPortlet(
-				group.getGroupId(), portletId)) {
+		if (isLocalStagingGroup(group.getGroupId()) &&
+			!isStagedPortlet(group.getGroupId(), portletId)) {
 
 			return group.getLiveGroup();
 		}
@@ -167,7 +162,9 @@ public class StagingGroupHelperImpl implements StagingGroupHelper {
 
 	@Override
 	public long getStagedPortletGroupId(long groupId, String portletId) {
-		if (!isStagedPortlet(groupId, portletId)) {
+		if (!isStagedPortlet(groupId, portletId) &&
+			!isRemoteStagingGroup(groupId)) {
+
 			Group liveGroup = fetchLiveGroup(groupId);
 
 			if (liveGroup != null) {

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
@@ -28,7 +28,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -173,21 +172,12 @@ public class TemplateInfoItemFieldSetProviderImpl
 		}
 
 		try {
-			long groupId = serviceContext.getScopeGroupId();
-
-			if (!_stagingGroupHelper.isStagedPortlet(
-					groupId, TemplatePortletKeys.TEMPLATE)) {
-
-				Group liveGroup = _stagingGroupHelper.fetchLiveGroup(groupId);
-
-				if (liveGroup != null) {
-					groupId = liveGroup.getGroupId();
-				}
-			}
-
 			return _templateEntryLocalService.getTemplateEntries(
-				groupId, infoItemClassName, infoItemFormVariationKey,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+				_stagingGroupHelper.getStagedPortletGroupId(
+					serviceContext.getScopeGroupId(),
+					TemplatePortletKeys.TEMPLATE),
+				infoItemClassName, infoItemFormVariationKey, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/renderer/TemplateInfoItemTemplatedRenderer.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/renderer/TemplateInfoItemTemplatedRenderer.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -172,20 +171,11 @@ public class TemplateInfoItemTemplatedRenderer<T>
 		}
 
 		try {
-			long groupId = serviceContext.getScopeGroupId();
-
-			if (!_stagingGroupHelper.isStagedPortlet(
-					groupId, TemplatePortletKeys.TEMPLATE)) {
-
-				Group liveGroup = _stagingGroupHelper.fetchLiveGroup(groupId);
-
-				if (liveGroup != null) {
-					groupId = liveGroup.getGroupId();
-				}
-			}
-
 			return _templateEntryLocalService.getTemplateEntries(
-				PortalUtil.getCurrentAndAncestorSiteGroupIds(groupId),
+				PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					_stagingGroupHelper.getStagedPortletGroupId(
+						serviceContext.getScopeGroupId(),
+						TemplatePortletKeys.TEMPLATE)),
 				infoItemClassName, infoItemFormVariationKey, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, null);
 		}


### PR DESCRIPTION
- LPS-176405 live groups web contents will appear in the item selector, if staging is not set for web contents
- LPS-176405 Adds new method to get the group taking into account if the portlet is staged or not
- LPS-176405 Reuse logic
- LPS-176405 Also apply to info item selectors
- LPS-176405 build.gradle
- LPS-176405 Use the local service calls + prepare for remote staging as well
