### PR TITLE
[TS] LPS-180299

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1036,6 +1036,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			String newLanguageIds = unicodeProperties.getProperty(
 				PropsKeys.LOCALES);
 
+			boolean invalidateLayoutSetTemplates = false;
+
 			if (Validator.isNotNull(newLanguageIds)) {
 				String oldLanguageIds = portletPreferences.getValue(
 					PropsKeys.LOCALES, StringPool.BLANK);
@@ -1048,20 +1050,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					LanguageUtil.resetAvailableLocales(companyId);
 
-					// Invalidate cache of all layout set prototypes that belong
-					// to this company. See LPS-36403.
-
-					Date date = new Date();
-
-					for (LayoutSetPrototype layoutSetPrototype :
-							_layoutSetPrototypeLocalService.
-								getLayoutSetPrototypes(companyId)) {
-
-						layoutSetPrototype.setModifiedDate(date);
-
-						_layoutSetPrototypeLocalService.
-							updateLayoutSetPrototype(layoutSetPrototype);
-					}
+					invalidateLayoutSetTemplates = true;
 				}
 			}
 
@@ -1098,6 +1087,24 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			portletPreferences.store();
+
+			if (invalidateLayoutSetTemplates) {
+
+				// Invalidate cache of all layout set prototypes that belong
+				// to this company. See LPS-36403.
+
+				Date date = new Date();
+
+				for (LayoutSetPrototype layoutSetPrototype :
+						_layoutSetPrototypeLocalService.getLayoutSetPrototypes(
+							companyId)) {
+
+					layoutSetPrototype.setModifiedDate(date);
+
+					_layoutSetPrototypeLocalService.updateLayoutSetPrototype(
+						layoutSetPrototype);
+				}
+			}
 		}
 		catch (LocaleException localeException) {
 			throw localeException;


### PR DESCRIPTION
Hi team, This PR aims to fix an undesired effect of the presence of the LayoutSetPrototypeModelListener included in LPS-150460. This ModelListener creates a Configuration which in turn calls the LanguageUtil.getAvailableLocales which populates the CompanyLocalesBag before the portal preferences related to LOCALES can be persisted causing some weird behavior when configuring languages in Instance Settings > Localization. The solution just move the update of the LayoutSetPrototypes after the persistence of the new locales. Could you please review it? Thanks in advance!