### PR TITLE
[TS] LPS-184372 - nosuchlayoutsetprototype exceptions can occur in remote staging due to missing verification | master

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutExportController.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutExportController.java
@@ -296,7 +296,7 @@ public class LayoutExportController implements ExportController {
 			portletDataContext.getParameterMap(),
 			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS);
 
-		if (!group.isStaged() && Validator.isNotNull(layoutSetPrototypeUuid) &&
+		if (Validator.isNotNull(layoutSetPrototypeUuid) &&
 			layoutSetPrototypeSettings) {
 
 			LayoutSetPrototype layoutSetPrototype =


### PR DESCRIPTION
Hi team!

This is being sent to Master branch since the code is present here, but cannot be tested due to [LPS-146160](https://issues.liferay.com/browse/LPS-146160). I've tested this fix primarily in 7.2, but in theory the code bases have seen virtually no changes and so they should work in the same manner.

This is a fix meant to help address a situation where due to a specific site template not being present on the 'live site' in a remote staging situation, pages are not accessible and a NoSuchLayoutSetPrototypeException occurs. While it's not the most graceful way to resolve the situation, the only way I could figure out how to handle it currently is to treat it in the same manner we do in import/export situations which is to actually verify if the template exists and toss the NoSuchLayoutSetPrototypeException *then*. While it won't fix currently existing sites with this error, it will address future cases. Please let me know if you have any suggestions or questions about this fix. Thanks!