### PR TITLE
LPS-174803 - Publish Templates - improper content count

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/init.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/init.jsp
@@ -53,6 +53,12 @@ if (exportImportConfiguration != null) {
 	settingsMap = exportImportConfiguration.getSettingsMap();
 
 	parameterMap = (Map<String, String[]>)settingsMap.get("parameterMap");
+
+	defaultRange = MapUtil.getString(parameterMap, "range");
+
+	if (Validator.isNull(defaultRange)) {
+		defaultRange = ExportImportDateUtil.RANGE_FROM_LAST_PUBLISH_DATE;
+	}
 }
 
 String range = ParamUtil.getString(portletRequest, ExportImportDateUtil.RANGE, null);


### PR DESCRIPTION
[LPS-174803](https://issues.liferay.com/browse/LPS-174803) set the defaultRange to the exportImportConfiguration's parameterMap's range if exportImportConfiguration is not null