### PR TITLE
LPS-187496

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/ExportImportLifecycleMessagingConfigurator.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/ExportImportLifecycleMessagingConfigurator.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import java.util.Dictionary;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+@Component(service = {})
+public class ExportImportLifecycleMessagingConfigurator {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
+		registerDestination(
+			bundleContext, DestinationConfiguration.DESTINATION_TYPE_SERIAL,
+			DestinationNames.EXPORT_IMPORT_LIFECYCLE_EVENT_ASYNC);
+		registerDestination(
+			bundleContext,
+			DestinationConfiguration.DESTINATION_TYPE_SYNCHRONOUS,
+			DestinationNames.EXPORT_IMPORT_LIFECYCLE_EVENT_SYNC);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		for (ServiceRegistration<Destination> serviceRegistration :
+				_serviceRegistrations) {
+
+			Destination destination = _bundleContext.getService(
+				serviceRegistration.getReference());
+
+			serviceRegistration.unregister();
+
+			destination.destroy();
+		}
+
+		_bundleContext = null;
+	}
+
+	protected ServiceRegistration<Destination> registerDestination(
+		BundleContext bundleContext, String destinationType,
+		String destinationName) {
+
+		DestinationConfiguration destinationConfiguration =
+			new DestinationConfiguration(destinationType, destinationName);
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
+
+		Dictionary<String, Object> dictionary =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"destination.name", destination.getName()
+			).build();
+
+		ServiceRegistration<Destination> serviceRegistration =
+			bundleContext.registerService(
+				Destination.class, destination, dictionary);
+
+		_serviceRegistrations.add(serviceRegistration);
+
+		return serviceRegistration;
+	}
+
+	private volatile BundleContext _bundleContext;
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private final Set<ServiceRegistration<Destination>> _serviceRegistrations =
+		new HashSet<>();
+
+}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/ExportImportLifecycleManagerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/ExportImportLifecycleManagerImpl.java
@@ -17,25 +17,13 @@ package com.liferay.exportimport.lifecycle;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleEvent;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleEventFactory;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleManager;
-import com.liferay.portal.kernel.messaging.Destination;
-import com.liferay.portal.kernel.messaging.DestinationConfiguration;
-import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
 import java.io.Serializable;
 
-import java.util.Dictionary;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -57,35 +45,6 @@ public class ExportImportLifecycleManagerImpl
 		fireExportImportLifecycleEvent(exportImportLifecycleEvent);
 	}
 
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
-
-		registerDestination(
-			bundleContext, DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-			DestinationNames.EXPORT_IMPORT_LIFECYCLE_EVENT_ASYNC);
-		registerDestination(
-			bundleContext,
-			DestinationConfiguration.DESTINATION_TYPE_SYNCHRONOUS,
-			DestinationNames.EXPORT_IMPORT_LIFECYCLE_EVENT_SYNC);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		for (ServiceRegistration<Destination> serviceRegistration :
-				_serviceRegistrations) {
-
-			Destination destination = _bundleContext.getService(
-				serviceRegistration.getReference());
-
-			serviceRegistration.unregister();
-
-			destination.destroy();
-		}
-
-		_bundleContext = null;
-	}
-
 	protected void fireExportImportLifecycleEvent(
 		ExportImportLifecycleEvent exportImportLifecycleEvent) {
 
@@ -101,43 +60,11 @@ public class ExportImportLifecycleManagerImpl
 			message.clone());
 	}
 
-	protected ServiceRegistration<Destination> registerDestination(
-		BundleContext bundleContext, String destinationType,
-		String destinationName) {
-
-		DestinationConfiguration destinationConfiguration =
-			new DestinationConfiguration(destinationType, destinationName);
-
-		Destination destination = _destinationFactory.createDestination(
-			destinationConfiguration);
-
-		Dictionary<String, Object> dictionary =
-			HashMapDictionaryBuilder.<String, Object>put(
-				"destination.name", destination.getName()
-			).build();
-
-		ServiceRegistration<Destination> serviceRegistration =
-			bundleContext.registerService(
-				Destination.class, destination, dictionary);
-
-		_serviceRegistrations.add(serviceRegistration);
-
-		return serviceRegistration;
-	}
-
-	private volatile BundleContext _bundleContext;
-
-	@Reference
-	private DestinationFactory _destinationFactory;
-
 	@Reference
 	private ExportImportLifecycleEventFactory
 		_exportImportLifecycleEventFactory;
 
 	@Reference
 	private MessageBus _messageBus;
-
-	private final Set<ServiceRegistration<Destination>> _serviceRegistrations =
-		new HashSet<>();
 
 }


### PR DESCRIPTION
Reasoning:

Exposing ExportImportLifecycleManagerImpl as a service causes that is activated when referenced from other component that needs to be activated. 

Both AsyncExportImportLifecycleMessageListener and SyncExportImportLifecycleMessageListener have a reference to the destination, but not to the manager implementation. That generates the missing reference when they are going to be activated, because to OSGi there is no need to activate ExportImportLifecycleManagerImpl

Similar commits where same solution was applied:
8989e10572e9 LPS-174300 Remove the service property from message listeners and let it be implied as immediate
ff1c6b253717 LPS-172157 Remove service property from OpenSamlBootstrap, SecurityConfigurationBootstrap, and let it be implied as immediate
857099804e79 LPS-170267 Remove service property from VerifyProcessTrackerOSGIComands and let it be implied as immediate
347056a21308 LPS-170114 Remove service property and let it be implied as immediate
9089c3fe69e2 LPS-170100 Remove service property and let it be implied as immediate
1f0ee0bf1a29 LPS-166684 Removed service property from MonitoringMessagingConfigurator and let it be implied as immediate
b2bcd38b6db8 LPS-167880 Removed service property from <componente> and let it be implied as immediate
216a9f22ec8a LPS-168709 Removed service property from Commerce Message Configurator and let it be implied as immediate
136378c5aa3f LPS-167128 Removed the service property from commerce message listeners and let it be implied as immediate
88e068764693 LPS-167128 Removed the service property from commerce servlets and let it be implied as immediate
264b0c24a5ae LPS-168208 Removed the service property from commerce components and let it be implied as immediate
