### PR TITLE
LPS-187608 When saving a web content, the domain of links to documents and media are not correctly validated 

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -788,11 +788,11 @@ public class DLReferencesExportImportContentProcessor
 							_virtualHostLocalService.getVirtualHosts(
 								group.getCompanyId())) {
 
-						String virtualHostname = virtualHost.getHostname();
+						String hostname = virtualHost.getHostname();
 
-						hostNames.add(Http.HTTP_WITH_SLASH + virtualHostname);
-						hostNames.add(Http.HTTPS_WITH_SLASH + virtualHostname);
-						hostNames.add(virtualHostname);
+						hostNames.add(hostname);
+						hostNames.add(Http.HTTP_WITH_SLASH + hostname);
+						hostNames.add(Http.HTTPS_WITH_SLASH + hostname);
 					}
 
 					for (String hostName : hostNames) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -36,16 +36,17 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.friendly.url.resolver.FileEntryFriendlyURLResolver;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -781,17 +782,18 @@ public class DLReferencesExportImportContentProcessor
 
 					hostNames.add(portalURL);
 
-					_companyLocalService.forEachCompany(
-						company -> {
-							String virtualHostname =
-								company.getVirtualHostname();
+					Group group = _groupLocalService.getGroup(groupId);
 
-							hostNames.add(
-								Http.HTTP_WITH_SLASH + virtualHostname);
-							hostNames.add(
-								Http.HTTPS_WITH_SLASH + virtualHostname);
-							hostNames.add(virtualHostname);
-						});
+					for (VirtualHost virtualHost :
+							_virtualHostLocalService.getVirtualHosts(
+								group.getCompanyId())) {
+
+						String virtualHostname = virtualHost.getHostname();
+
+						hostNames.add(Http.HTTP_WITH_SLASH + virtualHostname);
+						hostNames.add(Http.HTTPS_WITH_SLASH + virtualHostname);
+						hostNames.add(virtualHostname);
+					}
 
 					for (String hostName : hostNames) {
 						int curBeginPos = beginPos - hostName.length();
@@ -874,9 +876,6 @@ public class DLReferencesExportImportContentProcessor
 			"[a-fA-F0-9]{12}(?=[&,?]|$)");
 
 	@Reference
-	private CompanyLocalService _companyLocalService;
-
-	@Reference
 	private ConfigurationProvider _configurationProvider;
 
 	@Reference
@@ -899,5 +898,8 @@ public class DLReferencesExportImportContentProcessor
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private VirtualHostLocalService _virtualHostLocalService;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-187608

**Note:** I originally sent this PR to echo team, see https://github.com/liferay-echo/liferay-portal/pull/12449 but @ealonso said this was not related to the Echo components.

When saving a web content, the domain of links to documents and media are not correctly validated:

The [DLReferencesExportImportContentProcessor._validateDLReferences](https://github.com/liferay/liferay-portal/blob/feac395f4b9015ad13cebe7af5fa58d9bd8586b0/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java#L784-L794) method is getting the hostname list from all existing instances (=company table), but it should get the virtualhosts from the current instance.

This causes some problems when you:

 - Link a image from other instance => Liferay is not able to get the DLFileEntry from the other instance, so it will consider it as a broken link
 - Link a image using a virtual host from a site of current instance => If you fill in a broken link, Liferay will consider it as a external link and it won't be validated as we are not using its domain.

To solve the issue, I am getting the instance hostnames from VirtualHost table instead of using the ones from Company_ table