### PR TITLE
LPS-189811 Fix bug with importing Display Page Templates that can cause 404 errors when visiting them

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutFriendlyURLStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutFriendlyURLStagedModelDataHandler.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
@@ -126,14 +127,21 @@ public class LayoutFriendlyURLStagedModelDataHandler
 		layoutFriendlyURL = _getUniqueLayoutFriendlyURL(
 			portletDataContext, layoutFriendlyURL, existingLayoutFriendlyURL);
 
+		boolean privateLayout = portletDataContext.isPrivateLayout();
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout != null) {
+			privateLayout = layout.isPrivateLayout();
+		}
+
 		if (existingLayoutFriendlyURL == null) {
 			serviceContext.setUuid(layoutFriendlyURL.getUuid());
 
 			importedLayoutFriendlyURL =
 				_layoutFriendlyURLLocalService.addLayoutFriendlyURL(
 					userId, portletDataContext.getCompanyId(),
-					portletDataContext.getScopeGroupId(), plid,
-					portletDataContext.isPrivateLayout(),
+					portletDataContext.getScopeGroupId(), plid, privateLayout,
 					layoutFriendlyURL.getFriendlyURL(),
 					layoutFriendlyURL.getLanguageId(), serviceContext);
 		}
@@ -141,8 +149,7 @@ public class LayoutFriendlyURLStagedModelDataHandler
 			importedLayoutFriendlyURL =
 				_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
 					userId, portletDataContext.getCompanyId(),
-					portletDataContext.getScopeGroupId(), plid,
-					portletDataContext.isPrivateLayout(),
+					portletDataContext.getScopeGroupId(), plid, privateLayout,
 					layoutFriendlyURL.getFriendlyURL(),
 					layoutFriendlyURL.getLanguageId(), serviceContext);
 		}
@@ -206,5 +213,8 @@ public class LayoutFriendlyURLStagedModelDataHandler
 
 	@Reference
 	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 }


### PR DESCRIPTION
Default to using the same privateLayout value as the Layout itself, since it can legitimately be a different value that the import configuration's privateLayout value (for example, if the associated Layout is a Display Page Template, which are always public but can be exported/imported on a Private Pages export/import).

Ticket: [LPS-189811](https://liferay.atlassian.net/browse/LPS-189811)