### PR TITLE
[TS] LPS-188827 | Metadata doesn't update after page publishing

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -594,6 +594,14 @@ public class LayoutRevisionLocalServiceImpl
 				WorkflowConstants.STATUS_APPROVED, serviceContext);
 		}
 
+		Layout layout = _layoutLocalService.getLayout(layoutRevision.getPlid());
+
+		if (layout.isTypeContent()) {
+			updateStatus(
+				userId, layoutRevision.getLayoutRevisionId(),
+				WorkflowConstants.STATUS_APPROVED, serviceContext);
+		}
+
 		return layoutRevision;
 	}
 


### PR DESCRIPTION
hi Team,
Could you review this?

https://liferay.atlassian.net/browse/LPS-188827
Best,
Attila

----
The root cause of the issue is that the layoutRevision head flag is only updated when the page is inspected. My solution forces a status update after every layout revision in the case of content pages.
The solution is based on https://liferay.atlassian.net/browse/PTR-4080