### PR TITLE
[TS] LPS-190270

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionExporter.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionExporter.java
@@ -148,6 +148,12 @@ public class PermissionExporter {
 
 			Role role = RoleLocalServiceUtil.fetchRole(roleId);
 
+			Set<String> availableActionIds = entry.getValue();
+
+			if (availableActionIds.isEmpty() && !role.isSystem()) {
+				continue;
+			}
+
 			String roleName = role.getName();
 
 			if (role.isTeam()) {
@@ -173,8 +179,6 @@ public class PermissionExporter {
 			roleElement.addAttribute("description", role.getDescription());
 			roleElement.addAttribute("type", String.valueOf(role.getType()));
 			roleElement.addAttribute("subtype", role.getSubtype());
-
-			Set<String> availableActionIds = entry.getValue();
 
 			for (String actionId : availableActionIds) {
 				Element actionKeyElement = roleElement.addElement("action-key");

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/PermissionExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/PermissionExportImportTest.java
@@ -129,11 +129,20 @@ public class PermissionExportImportTest {
 			Group exportGroup, Role role, String exportResourcePrimKey)
 		throws Exception {
 
+		addPortletPermissions(
+			exportGroup, role, exportResourcePrimKey, _ACTION_IDS);
+	}
+
+	protected void addPortletPermissions(
+			Group exportGroup, Role role, String exportResourcePrimKey,
+			String[] actionIds)
+		throws Exception {
+
 		ResourcePermissionServiceUtil.setIndividualResourcePermissions(
 			exportGroup.getGroupId(), TestPropsValues.getCompanyId(),
 			_PORTLET_ID, exportResourcePrimKey,
 			HashMapBuilder.put(
-				role.getRoleId(), _ACTION_IDS
+				role.getRoleId(), actionIds
 			).build());
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-190270

**Description**
Role with no permissions is exported to portlet permission if it had some permissions associated to it at one point.  This is because once we grant permissions to a role, an entry is created in the ResourcePermission table, and it will persist even if we completely remove these permissions (the entry now shows the role has no permissions, but the entry is still present in the DB).

This is not a problem when exporting individual portlets, as the [PortletDatacontextImpl class will prevent the role from being created](https://github.com/liferay/liferay-portal/blob/master/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java#L1456-L1464) upon importation.

However when exporting/importing layouts with permissions, we must not follow this same rule of excluding role creation due to LPS-41889 (ticket context is lost, but the commit can be found here: https://github.com/liferay/liferay-portal/commit/0e347080e4e6f293ed6485a9c6f3e1850a745af6)

Please let me know if you have any questions, thanks!

