### PR TITLE
[TS] LPS-191924: retrieve updated Layout name from LayoutRevision to build correct path in breadcrumbs

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -93,6 +93,10 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 
 			Object bean = _layout;
 
+			if (methodName.equals("getBreadcrumb")) {
+				_layout.setName(_layoutRevision.getName());
+			}
+
 			if (_layoutRevisionMethodNames.contains(methodName)) {
 				try {
 					Class<?> layoutRevisionClass = _layoutRevision.getClass();


### PR DESCRIPTION
[LPS-191924](https://liferay.atlassian.net/browse/LPS-191924) - After a page name update, a "Link to Page" field in a web content structure, shows old page name while staging with page versioning is on