### PR TITLE
[TS] LPS-185987 | DDL entry deletion is not published to Live via the Staging option of the DDL portlet

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/test/DDLDisplayPortletDataHandlerTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/test/DDLDisplayPortletDataHandlerTest.java
@@ -73,4 +73,9 @@ public class DDLDisplayPortletDataHandlerTest
 		return false;
 	}
 
+	@Override
+	protected boolean isDisplayPortlet() {
+		return false;
+	}
+
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/data/handler/DDLDisplayPortletDataHandler.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/data/handler/DDLDisplayPortletDataHandler.java
@@ -16,11 +16,15 @@ package com.liferay.dynamic.data.lists.web.internal.exportimport.data.handler;
 
 import com.liferay.dynamic.data.lists.constants.DDLConstants;
 import com.liferay.dynamic.data.lists.constants.DDLPortletKeys;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
 import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
-import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerBoolean;
+import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 
@@ -39,6 +43,8 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class DDLDisplayPortletDataHandler extends BasePortletDataHandler {
 
+	public static final String NAMESPACE = "dynamic_data_lists";
+
 	public static final String SCHEMA_VERSION = "4.0.0";
 
 	@Override
@@ -51,12 +57,37 @@ public class DDLDisplayPortletDataHandler extends BasePortletDataHandler {
 		return DDLConstants.SERVICE_NAME;
 	}
 
+	@Override
+	public boolean isDisplayPortlet() {
+		return false;
+	}
+
+	@Override
+	public void prepareManifestSummary(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		_ddlPortletDataHandler.prepareManifestSummary(
+			portletDataContext, portletPreferences);
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);
 		setDataPortletPreferences(
 			"displayDDMTemplateId", "formDDMTemplateId", "recordSetId");
-		setExportControls(new PortletDataHandlerControl[0]);
+		setDeletionSystemEventStagedModelTypes(
+			new StagedModelType(DDLRecord.class),
+			new StagedModelType(DDLRecordSet.class));
+		setExportControls(
+			new PortletDataHandlerBoolean(
+				NAMESPACE, "record-sets", true, false, null,
+				DDLRecordSet.class.getName()),
+			new PortletDataHandlerBoolean(
+				NAMESPACE, "records", true, false, null,
+				DDLRecord.class.getName()));
+		setStagingControls(getExportControls());
 	}
 
 	@Override
@@ -76,8 +107,14 @@ public class DDLDisplayPortletDataHandler extends BasePortletDataHandler {
 		portletPreferences.setValue("recordSetId", StringPool.BLANK);
 		portletPreferences.setValue("spreadsheet", Boolean.FALSE.toString());
 
-		return portletPreferences;
+		return _ddlPortletDataHandler.deleteData(
+			portletDataContext, portletId, portletPreferences);
 	}
+
+	@Reference(
+		target = "(javax.portlet.name=" + DDLPortletKeys.DYNAMIC_DATA_LISTS + ")"
+	)
+	private PortletDataHandler _ddlPortletDataHandler;
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;


### PR DESCRIPTION
Hi Team,
Could you review this?

https://liferay.atlassian.net/browse/LPS-185987
Best,
Attila

-----------------------------------

I created a new fix. I returned to my original approach to fix the issue in the DDLDisplayPortletDataHandler. The layout could be displayed differently by modifying publish_portlet_publish_or_copy.jsp similarly to #359, but the actual delete event was not exported by only this modification. As I had to modify the DDLDisplayPortletDataHandler anyway I returned to my original approach. The fix behaves in a similar manner to the BlogsPortlet and redirects some actions to the related adminPortlets.