### PR TITLE
[TS] LPS-192705 | Portlet preferences are getting lost during the propagation when using virtualhost other than the default one

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
@@ -146,17 +146,22 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 			}
 
 			if (!serviceBuilderPortletPreferencesList.isEmpty()) {
-				com.liferay.portal.kernel.model.PortletPreferences
-					serviceBuilderPortletPreferences =
-						serviceBuilderPortletPreferencesList.get(0);
+				for (com.liferay.portal.kernel.model.PortletPreferences
+						serviceBuilderPortletPreferences :
+							serviceBuilderPortletPreferencesList) {
 
-				PortletPreferences originalPortletPreferences =
-					_portletPreferenceValueLocalService.getPreferences(
-						serviceBuilderPortletPreferences);
+					if (serviceBuilderPortletPreferences.getCompanyId() ==
+							portletDataContext.getCompanyId()) {
 
-				siteNavigationMenuId = GetterUtil.getLong(
-					originalPortletPreferences.getValue(
-						"siteNavigationMenuId", "0"));
+						PortletPreferences originalPortletPreferences =
+							_portletPreferenceValueLocalService.getPreferences(
+								serviceBuilderPortletPreferences);
+
+						siteNavigationMenuId = GetterUtil.getLong(
+							originalPortletPreferences.getValue(
+								"siteNavigationMenuId", "0"));
+					}
+				}
 			}
 
 			try {


### PR DESCRIPTION
Hi Team,
Could you review this?

https://liferay.atlassian.net/browse/LPS-192705
Best,
Attila

----

The root cause of the issue is that we store all shared preferences under plid = 0 and the localservice gets them all for plid = 0.
My solution is to simply filter the correct one from the result list based on companyID.