### PR TITLE
[TS] LPS-189952 Always force propagation from site template to site when when updateLayoutSetPrototypeLinkEnabled

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1564,14 +1564,6 @@ public class SitesImpl implements Sites {
 			layoutSetPrototypeUuid);
 
 		LayoutLocalServiceUtil.updatePriorities(groupId, privateLayout);
-
-		// Force propagation from site template to site. See LPS-48206.
-
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
-		mergeLayoutSetPrototypeLayouts(
-			GroupLocalServiceUtil.getGroup(groupId),
-			LayoutSetLocalServiceUtil.getLayoutSet(groupId, privateLayout));
 	}
 
 	private String _acquireLock(


### PR DESCRIPTION
Ticket:
https://liferay.atlassian.net/browse/LPS-189952
Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/138708
Root cause:
I found that when accessing the page, the mergeLayoutSetPrototypeLayouts process will be executed and acts as a background task. This is what causes the Home page not to exist when accessing the page for the first time.
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java#L1565-L1567
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java#L4056-L4062
Solution:
Always force propagation from site template to site when updateLayoutSetPrototypeLinkEnabled.
Thanks.