### PR TITLE
LPS-195670 Prevent ExportImportServiceConfigurationUpgradeProcess process hanging due to circular dependency

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelper.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelper.java
@@ -21,4 +21,8 @@ public interface ExportImportServiceConfigurationWhitelistedURLPatternsHelper {
 
 	public void rebuildURLPatternMappers();
 
+	public void removeURLPatternMapper(long companyId);
+
+	public void removeURLPatternMappers();
+
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
@@ -152,7 +152,7 @@ public class ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
-		rebuildURLPatternMappers();
+		removeURLPatternMappers();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
@@ -140,6 +139,6 @@ public class ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl
 	private SettingsLocatorHelper _settingsLocatorHelper;
 
 	private final Map<Long, URLPatternMapper<Boolean>> _urlPatternMappers =
-		Collections.synchronizedMap(new LinkedHashMap<>());
+		Collections.synchronizedMap(new HashMap<>());
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
@@ -13,7 +13,6 @@ import com.liferay.petra.url.pattern.mapper.URLPatternMapperFactory;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -42,11 +41,7 @@ public class ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl
 			companyId);
 
 		if (urlPatternMapper == null) {
-			urlPatternMapper = _urlPatternMappers.get(CompanyConstants.SYSTEM);
-
-			if (urlPatternMapper == null) {
-				return false;
-			}
+			return false;
 		}
 
 		Boolean result = urlPatternMapper.getValue(url);

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
@@ -116,6 +116,16 @@ public class ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl
 			});
 	}
 
+	@Override
+	public void removeURLPatternMapper(long companyId) {
+		_urlPatternMappers.remove(companyId);
+	}
+
+	@Override
+	public void removeURLPatternMappers() {
+		_urlPatternMappers.clear();
+	}
+
 	@Activate
 	protected void activate(Map<String, Object> properties) {
 		rebuildURLPatternMappers();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
@@ -37,6 +37,30 @@ public class ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl
 
 	@Override
 	public boolean isWhitelistedURL(long companyId, String url) {
+		if (!_urlPatternMappers.containsKey(companyId)) {
+			try {
+				rebuildURLPatternMapper(companyId);
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Unable to instantiate URL pattern mapper for ",
+							"company ", companyId),
+						exception);
+				}
+				else {
+					_log.error(
+						StringBundler.concat(
+							"Unable to instantiate URL pattern mapper for ",
+							"company ", companyId, ": ",
+							exception.getMessage()));
+				}
+
+				return false;
+			}
+		}
+
 		URLPatternMapper<Boolean> urlPatternMapper = _urlPatternMappers.get(
 			companyId);
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl.java
@@ -99,7 +99,7 @@ public class ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl
 				validateLayoutReferencesWhitelistedURLPatterns();
 
 		if (ArrayUtil.isEmpty(whitelistedURLPatterns)) {
-			_urlPatternMappers.remove(companyId);
+			_urlPatternMappers.put(companyId, null);
 
 			return;
 		}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/persistence/listener/ExportImportServiceConfigurationModelListener.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/persistence/listener/ExportImportServiceConfigurationModelListener.java
@@ -43,7 +43,7 @@ public class ExportImportServiceConfigurationModelListener
 					get();
 
 		exportImportServiceConfigurationWhitelistedURLPatternsHelper.
-			rebuildURLPatternMappers();
+			removeURLPatternMappers();
 	}
 
 	@Override
@@ -56,14 +56,9 @@ public class ExportImportServiceConfigurationModelListener
 					_exportImportServiceConfigurationWhitelistedURLPatternsHelperSnapshot.
 						get();
 
-			ExportImportServiceConfiguration exportImportServiceConfiguration =
-				ConfigurableUtil.createConfigurable(
-					ExportImportServiceConfiguration.class, properties);
-
 			exportImportServiceConfigurationWhitelistedURLPatternsHelper.
-				rebuildURLPatternMapper(
-					GetterUtil.getLong(properties.get("companyId")),
-					exportImportServiceConfiguration);
+				removeURLPatternMapper(
+					GetterUtil.getLong(properties.get("companyId")));
 		}
 		catch (Exception exception) {
 			throw new ConfigurationModelListenerException(


### PR DESCRIPTION
Ticket: [LPS-195670](https://liferay.atlassian.net/browse/LPS-195670)

The ExportImportServiceConfigurationUpgradeProcess process is hanging due to a sort of circular dependency. When running the upgrade, we update the `ExportImportConfiguration`, which triggers a `ModelListener` that calls the `activate` method of the `ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl`. This in turn tries to look up all company values of the `ExportImportServiceConfiguration`, which hangs indefinitely since the `ExportImportServiceConfiguration` has not finished upgrading yet.

This fix changes the caching mechanism inside the `ExportImportServiceConfigurationWhitelistedURLPatternsHelperImpl` class to a lazy-loading one. This prevents us from needing to populate the cache during its `activate` method, thus preventing the problem from occurring. Instead, the cache gets loaded on demand when the `isWhitelistedURL` method is called, which shouldn't happen until the ExportImportServiceConfiguration is already available.