### PR TITLE
LPS-198068 The documents and media URL of Image Fragment is not correctly displayed on the Live environment

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
@@ -338,6 +338,10 @@ public class EditableValuesMappingExportImportContentProcessor
 		classPK = MapUtil.getLong(primaryKeys, classPK, classPK);
 
 		editableJSONObject.put("classPK", classPK);
+
+		if (editableJSONObject.has("fileEntryId")) {
+			editableJSONObject.put("fileEntryId", classPK);
+		}
 	}
 
 	private static final String _DDM_TEMPLATE = "ddmTemplate_";


### PR DESCRIPTION
[LPS-198068](https://liferay.atlassian.net/browse/LPS-198068)

The fix is basically the same as in [DataValuesMappingExportImportContentProcessor](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/exportimport/content/processor/DataValuesMappingExportImportContentProcessor.java#L649-L651):
```
		if (jsonObject.has("fileEntryId")) {
			jsonObject.put("fileEntryId", classPK);
		}
```
So `fileEntryId` will also be replaced during import.
