### PR TITLE
[TS] LPS-198958 include pound char to stop reference

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -930,8 +930,9 @@ public class DLReferencesExportImportContentProcessor
 		StringPool.BACK_SLASH + StringPool.APOSTROPHE,
 		StringPool.BACK_SLASH + StringPool.QUOTE, StringPool.CLOSE_BRACKET,
 		StringPool.CLOSE_CURLY_BRACE, StringPool.CLOSE_PARENTHESIS,
-		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.PIPE, StringPool.POUND,
-		StringPool.QUOTE, StringPool.QUOTE_ENCODED, StringPool.SPACE
+		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.PIPE,
+		StringPool.POUND, StringPool.QUOTE, StringPool.QUOTE_ENCODED,
+		StringPool.SPACE
 	};
 
 	private static final String[] _DL_REFERENCE_STOP_STRINGS = {
@@ -940,8 +941,8 @@ public class DLReferencesExportImportContentProcessor
 		StringPool.BACK_SLASH + StringPool.QUOTE, StringPool.CLOSE_BRACKET,
 		StringPool.CLOSE_CURLY_BRACE, StringPool.CLOSE_PARENTHESIS,
 		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.NEW_LINE,
-		StringPool.PIPE, StringPool.POUND, StringPool.QUESTION, StringPool.QUOTE,
-		StringPool.QUOTE_ENCODED, StringPool.SPACE
+		StringPool.PIPE, StringPool.POUND, StringPool.QUESTION,
+		StringPool.QUOTE, StringPool.QUOTE_ENCODED, StringPool.SPACE
 	};
 
 	private static final int _OFFSET_COLON_PORT = 6;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -930,7 +930,7 @@ public class DLReferencesExportImportContentProcessor
 		StringPool.BACK_SLASH + StringPool.APOSTROPHE,
 		StringPool.BACK_SLASH + StringPool.QUOTE, StringPool.CLOSE_BRACKET,
 		StringPool.CLOSE_CURLY_BRACE, StringPool.CLOSE_PARENTHESIS,
-		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.PIPE,
+		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.PIPE, StringPool.POUND,
 		StringPool.QUOTE, StringPool.QUOTE_ENCODED, StringPool.SPACE
 	};
 
@@ -940,7 +940,7 @@ public class DLReferencesExportImportContentProcessor
 		StringPool.BACK_SLASH + StringPool.QUOTE, StringPool.CLOSE_BRACKET,
 		StringPool.CLOSE_CURLY_BRACE, StringPool.CLOSE_PARENTHESIS,
 		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.NEW_LINE,
-		StringPool.PIPE, StringPool.QUESTION, StringPool.QUOTE,
+		StringPool.PIPE, StringPool.POUND, StringPool.QUESTION, StringPool.QUOTE,
 		StringPool.QUOTE_ENCODED, StringPool.SPACE
 	};
 


### PR DESCRIPTION
Hi Team,

Could you please review this pull request?
https://liferay.atlassian.net/browse/LPS-198958
Thank you!

----
**Reproduction Steps:**

1. Go to [Global site > Content & Data > Documents and Media > + > Multiple File Upload]

2. Drag the attached svg image

3. Export the documents and media to LAR file and download it

4. Go to [Global site > Design > Templates > Widget Templates > + > Site Map Template]

5. Set any name, add the following code and save

`<svg role="img" aria-label="左にスライド" width="24" height="24" viewBox="0 0 24 24"><use xlink:href="/documents/d/global/metrotokyo_icon#icon-metrotokyo-chevron-left-01"></use></svg>`

6. Optional: delete all default templates

7. Export the template to LAR file and download it

8. Shutdown liferay

9. Start a new clean bundle

10. Login as admin

11. Go to [Global site > Content & Data > Documents and Media] and imported the LAR file

12. Go to [Global site > Design > Templates > Widget Templates] and imported the LAR file

13, Edit the imported template
**Expected Result:** Imported data is the same as exported data
**Actual Result:** The URL has changed
`<use xlink:href="/documents/d/global/metrotokyo_icon">`

Solution:
Include pound character in the list of characters which stops the referencing.