### PR TITLE
LPS-201703 Ensure connection closing to avoid connection leak

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -719,9 +719,8 @@ public class CTCollectionLocalServiceImpl
 
 			DataSource dataSource = ctPersistence.getDataSource();
 
-			Connection connection = dataSource.getConnection();
-
-			try (PreparedStatement preparedStatement =
+			try (Connection connection = dataSource.getConnection();
+				PreparedStatement preparedStatement =
 					connection.prepareStatement(
 						StringBundler.concat(
 							"select count(*) from ",


### PR DESCRIPTION
This pull fixes [LPS-201703](https://liferay.atlassian.net/browse/LPS-201703)

**Reproduction steps**

- Add property to your portal-ext.properties: jdbc.default.leakDetectionThreshold=15000

- Start instance

- Enable publications going to Global Menu → Applications tab → Publications

- Create a new publication

- Edit the home page and add a button fragment to the page. Publish changes

- In Publications menu → Review changes → Publish all changes

- Wait 15 seconds

- Check application logs

**Expected behavior**

- No warnings regarding connection leaks appear in log

**Actual behavior**

- The following connection leaks warning appear in the logs (it appears twice):

```
WARN  [HikariPool-1 housekeeper][ProxyLeakTask:84] Connection leak detection triggered for org.hsqldb.jdbc.JDBCConnection@49d26eba on thread http-nio-8080-exec-7, stack trace follows
java.lang.Exception: Apparent connection leak detected
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:128) ~[hikaricp.jar:?]
	at org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy$LazyConnectionInvocationHandler.getTargetConnection(LazyConnectionDataSourceProxy.java:412) ~[spring-jdbc.jar:5.2.24.RELEASE]
	at org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy$LazyConnectionInvocationHandler.invoke(LazyConnectionDataSourceProxy.java:385) ~[spring-jdbc.jar:5.2.24.RELEASE]
	at com.sun.proxy.$Proxy48.prepareStatement(Unknown Source) ~[?:?]
	at com.liferay.change.tracking.service.impl.CTCollectionLocalServiceImpl.hasUnapprovedChanges(CTCollectionLocalServiceImpl.java:703) ~[?:?]
	...
``` 

