### PR TITLE
LPS-200974

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/test/DDLDisplayPortletDataHandlerTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/test/DDLDisplayPortletDataHandlerTest.java
@@ -56,7 +56,7 @@ public class DDLDisplayPortletDataHandlerTest
 
 	@Override
 	protected boolean isDataPortletInstanceLevel() {
-		return true;
+		return false;
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/data/handler/DDLDisplayPortletDataHandler.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/data/handler/DDLDisplayPortletDataHandler.java
@@ -49,6 +49,11 @@ public class DDLDisplayPortletDataHandler extends BasePortletDataHandler {
 	}
 
 	@Override
+	public boolean isDataPortletInstanceLevel() {
+		return _ddlPortletDataHandler.isDataPortletInstanceLevel();
+	}
+
+	@Override
 	public boolean isDisplayPortlet() {
 		return false;
 	}


### PR DESCRIPTION
Hi Team,
Could you review this?

https://liferay.atlassian.net/browse/LPS-200974
Best,
Attila

------

The modified code only affects this behavior based on my searches the isDataPortletInstanceLevel in the PortletDataHandlers is only used at one specific point in the export/import. The root cause of the issue is that the data changes related to deletion events are only exported from XX hours when the selected portlet is not an instanceLevel portlet.